### PR TITLE
Tolerate dcrwallet connection failures.

### DIFF
--- a/background/background.go
+++ b/background/background.go
@@ -108,11 +108,15 @@ func (n *NotificationHandler) Notify(method string, params json.RawMessage) erro
 		return nil
 	}
 
-	walletClients, err := n.Wallets.Clients(n.Ctx, n.NetParams)
-	if err != nil {
-		log.Error(err)
-		// If this fails, there is nothing more we can do. Return.
+	walletClients, failedConnections := n.Wallets.Clients(n.Ctx, n.NetParams)
+	if len(walletClients) == 0 {
+		// If no wallet clients, there is nothing more we can do. Return.
+		log.Error("Could not connect to any wallets")
 		return nil
+	}
+	if failedConnections > 0 {
+		log.Errorf("Failed to connect to %d wallet(s), proceeding with only %d",
+			failedConnections, len(walletClients))
 	}
 
 	for _, ticket := range unconfirmedFees {

--- a/main.go
+++ b/main.go
@@ -79,9 +79,9 @@ func run(ctx context.Context) error {
 	wallets := rpc.SetupWallet(ctx, &shutdownWg, cfg.WalletUser, cfg.WalletPass,
 		cfg.WalletHosts, cfg.walletCert)
 	// Dial once just to validate config.
-	_, err = wallets.Clients(ctx, cfg.netParams.Params)
-	if err != nil {
-		log.Error(err)
+	_, failedConnections := wallets.Clients(ctx, cfg.netParams.Params)
+	if failedConnections > 0 {
+		log.Errorf("Failed RPC connection on %d of %d voting wallets", failedConnections, len(cfg.WalletHosts))
 		requestShutdown()
 		shutdownWg.Wait()
 		return err

--- a/webapi/setvotechoices.go
+++ b/webapi/setvotechoices.go
@@ -59,9 +59,9 @@ func setVoteChoices(c *gin.Context) {
 			for _, walletClient := range walletClients {
 				err = walletClient.SetVoteChoice(agenda, choice, ticket.Hash)
 				if err != nil {
+					// If this fails, we still want to try the other wallets, so
+					// don't return an error response, just log an error.
 					log.Errorf("SetVoteChoice failed: %v", err)
-					sendErrorResponse("dcrwallet RPC error", http.StatusInternalServerError, c)
-					return
 				}
 			}
 		}


### PR DESCRIPTION
If at least 1 wallet connection succeeds, vspd should proceed to use the connected wallet(s). Only error out if all wallet connections fail.