### PR TITLE
Return parsable error codes instead of just a string

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -4,8 +4,16 @@
 
 - Success responses use HTTP status 200 and a JSON encoded body.
 
-- Error responses use either HTTP status 500 or 400, and a JSON encoded error
-  in the body, e.g. `{"error":"Description"}`.
+- Error responses use HTTP status 500 to indicate a server error or 400 to
+  indiciate a client error, and will include a JSON body describing the error.
+  For example:
+
+  ```json
+  {"code": 9, "message":"invalid vote choices"}
+  ```
+
+  A full list of error codes can be looked up in
+  [webapi/errors.go](../webapi/errors.go)
 
 - Requests which reference specific tickets need to be properly signed as
   described in [two-way-accountability.md](./two-way-accountability.md).

--- a/webapi/errors.go
+++ b/webapi/errors.go
@@ -1,0 +1,84 @@
+package webapi
+
+import "net/http"
+
+type apiError int
+
+const (
+	errBadRequest apiError = iota
+	errInternalError
+	errVspClosed
+	errFeeAlreadyReceived
+	errInvalidFeeTx
+	errFeeTooSmall
+	errUnknownTicket
+	errTicketCannotVote
+	errFeeExpired
+	errInvalidVoteChoices
+	errBadSignature
+	errInvalidPrivKey
+)
+
+// httpStatus maps application error codes to HTTP status codes.
+func (e apiError) httpStatus() int {
+	switch e {
+	case errBadRequest:
+		return http.StatusBadRequest
+	case errInternalError:
+		return http.StatusInternalServerError
+	case errVspClosed:
+		return http.StatusBadRequest
+	case errFeeAlreadyReceived:
+		return http.StatusBadRequest
+	case errInvalidFeeTx:
+		return http.StatusBadRequest
+	case errFeeTooSmall:
+		return http.StatusBadRequest
+	case errUnknownTicket:
+		return http.StatusBadRequest
+	case errTicketCannotVote:
+		return http.StatusBadRequest
+	case errFeeExpired:
+		return http.StatusBadRequest
+	case errInvalidVoteChoices:
+		return http.StatusBadRequest
+	case errBadSignature:
+		return http.StatusBadRequest
+	case errInvalidPrivKey:
+		return http.StatusBadRequest
+	default:
+		return http.StatusInternalServerError
+	}
+}
+
+// defaultMessage returns a descriptive error string for a given error code.
+func (e apiError) defaultMessage() string {
+	switch e {
+	case errBadRequest:
+		return "bad request"
+	case errInternalError:
+		return "internal error"
+	case errVspClosed:
+		return "vsp is closed"
+	case errFeeAlreadyReceived:
+		return "fee tx already received"
+	case errInvalidFeeTx:
+		return "invalid fee transaction"
+	case errFeeTooSmall:
+		return "fee too small"
+	case errUnknownTicket:
+		return "unknown ticket"
+	case errTicketCannotVote:
+		return "ticket not eligible to vote"
+	case errFeeExpired:
+		return "fee has expired"
+	case errInvalidVoteChoices:
+		return "invalid vote choices"
+	case errBadSignature:
+		return "bad request signature"
+	case errInvalidPrivKey:
+		return "invalid private key"
+	default:
+		return "unknown error"
+	}
+}

--- a/webapi/ticketstatus.go
+++ b/webapi/ticketstatus.go
@@ -1,7 +1,6 @@
 package webapi
 
 import (
-	"net/http"
 	"time"
 
 	"github.com/decred/vspd/database"
@@ -18,15 +17,15 @@ func ticketStatus(c *gin.Context) {
 	knownTicket := c.MustGet("KnownTicket").(bool)
 
 	if !knownTicket {
-		log.Warnf("Invalid ticket from %s", c.ClientIP())
-		sendErrorResponse("invalid ticket", http.StatusBadRequest, c)
+		log.Warnf("Unknown ticket from %s", c.ClientIP())
+		sendError(errUnknownTicket, c)
 		return
 	}
 
 	var ticketStatusRequest TicketStatusRequest
 	if err := binding.JSON.BindBody(rawRequest, &ticketStatusRequest); err != nil {
 		log.Warnf("Bad ticketstatus request from %s: %v", c.ClientIP(), err)
-		sendErrorResponse(err.Error(), http.StatusBadRequest, c)
+		sendErrorWithMsg(err.Error(), errBadRequest, c)
 		return
 	}
 


### PR DESCRIPTION
Errors bodies changed from:

```
{"error":"invalid vote choices"}
```

to

```
{"code": 9, "message":"invalid vote choices"}
```


Also
- In most cases of internal error, just return a string "internal error" rather than something unnecessarily descriptive.
- Check if VSP is closed before /payfee

Rebased on #109
Closes #67 