### PR TITLE
Move feeAddressExpiration into webapi package.

### DIFF
--- a/main.go
+++ b/main.go
@@ -6,16 +6,11 @@ import (
 	"fmt"
 	"os"
 	"sync"
-	"time"
 
 	"github.com/decred/vspd/background"
 	"github.com/decred/vspd/database"
 	"github.com/decred/vspd/rpc"
 	"github.com/decred/vspd/webapi"
-)
-
-const (
-	defaultFeeAddressExpiration = 1 * time.Hour
 )
 
 func main() {
@@ -89,11 +84,10 @@ func run(ctx context.Context) error {
 
 	// Create and start webapi server.
 	apiCfg := webapi.Config{
-		VSPFee:               cfg.VSPFee,
-		NetParams:            cfg.netParams.Params,
-		FeeAddressExpiration: defaultFeeAddressExpiration,
-		SupportEmail:         cfg.SupportEmail,
-		VspClosed:            cfg.VspClosed,
+		VSPFee:       cfg.VSPFee,
+		NetParams:    cfg.netParams.Params,
+		SupportEmail: cfg.SupportEmail,
+		VspClosed:    cfg.VspClosed,
 	}
 	err = webapi.Start(ctx, shutdownRequestChannel, &shutdownWg, cfg.Listen, db,
 		dcrd, wallets, cfg.WebServerDebug, apiCfg)

--- a/webapi/getfeeaddress.go
+++ b/webapi/getfeeaddress.go
@@ -123,7 +123,7 @@ func feeAddress(c *gin.Context) {
 				sendErrorResponse("fee error", http.StatusInternalServerError, c)
 				return
 			}
-			ticket.FeeExpiration = now.Add(cfg.FeeAddressExpiration).Unix()
+			ticket.FeeExpiration = now.Add(feeAddressExpiration).Unix()
 			ticket.FeeAmount = newFee.ToCoin()
 
 			err = db.UpdateTicket(ticket)
@@ -162,7 +162,7 @@ func feeAddress(c *gin.Context) {
 	}
 
 	now := time.Now()
-	expire := now.Add(cfg.FeeAddressExpiration).Unix()
+	expire := now.Add(feeAddressExpiration).Unix()
 
 	confirmed := rawTicket.Confirmations >= requiredConfs
 

--- a/webapi/webapi.go
+++ b/webapi/webapi.go
@@ -19,12 +19,11 @@ import (
 )
 
 type Config struct {
-	VSPFee               float64
-	NetParams            *chaincfg.Params
-	FeeAccountName       string
-	FeeAddressExpiration time.Duration
-	SupportEmail         string
-	VspClosed            bool
+	VSPFee         float64
+	NetParams      *chaincfg.Params
+	FeeAccountName string
+	SupportEmail   string
+	VspClosed      bool
 }
 
 const (
@@ -33,6 +32,9 @@ const (
 	// requiredConfs is the number of confirmations required to consider a
 	// ticket purchase or a fee transaction to be final.
 	requiredConfs = 6
+	// feeAddressExpiration is the length of time a fee returned by /feeaddress
+	// remains valid. After this time, a new fee must be requested.
+	feeAddressExpiration = 1 * time.Hour
 )
 
 var cfg Config


### PR DESCRIPTION
I don't really see any good reason this value should be configurable, so moving it down into the webapi package and saying this closes #49 