### PR TITLE
Improve handling of fee status.

### DIFF
--- a/database/ticket_test.go
+++ b/database/ticket_test.go
@@ -19,7 +19,7 @@ func exampleTicket() Ticket {
 		VotingWIF:         "VotingKey",
 		FeeTxHex:          "FeeTransction",
 		FeeTxHash:         "",
-		FeeConfirmed:      true,
+		FeeTxStatus:       FeeBroadcast,
 	}
 }
 
@@ -84,7 +84,7 @@ func testGetTicketByHash(t *testing.T) {
 		retrieved.VotingWIF != ticket.VotingWIF ||
 		retrieved.FeeTxHex != ticket.FeeTxHex ||
 		retrieved.FeeTxHash != ticket.FeeTxHash ||
-		retrieved.FeeConfirmed != ticket.FeeConfirmed {
+		retrieved.FeeTxStatus != ticket.FeeTxStatus {
 		t.Fatal("retrieved ticket value didnt match expected")
 	}
 

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -56,13 +56,13 @@ func setup(ctx context.Context, shutdownWg *sync.WaitGroup, user, pass, addr str
 		if c != nil {
 			select {
 			case <-c.Done():
-				log.Debugf("RPC already closed (%s)", addr)
+				log.Tracef("RPC already closed (%s)", addr)
 
 			default:
 				if err := c.Close(); err != nil {
 					log.Errorf("Failed to close RPC (%s): %v", addr, err)
 				} else {
-					log.Debugf("RPC closed (%s)", addr)
+					log.Tracef("RPC closed (%s)", addr)
 				}
 			}
 		}

--- a/webapi/errors.go
+++ b/webapi/errors.go
@@ -17,6 +17,7 @@ const (
 	errInvalidVoteChoices
 	errBadSignature
 	errInvalidPrivKey
+	errFeeNotReceived
 )
 
 // httpStatus maps application error codes to HTTP status codes.
@@ -45,6 +46,8 @@ func (e apiError) httpStatus() int {
 	case errBadSignature:
 		return http.StatusBadRequest
 	case errInvalidPrivKey:
+		return http.StatusBadRequest
+	case errFeeNotReceived:
 		return http.StatusBadRequest
 	default:
 		return http.StatusInternalServerError
@@ -78,6 +81,8 @@ func (e apiError) defaultMessage() string {
 		return "bad request signature"
 	case errInvalidPrivKey:
 		return "invalid private key"
+	case errFeeNotReceived:
+		return "no fee tx received for this ticket"
 	default:
 		return "unknown error"
 	}

--- a/webapi/getfeeaddress.go
+++ b/webapi/getfeeaddress.go
@@ -83,7 +83,9 @@ func feeAddress(c *gin.Context) {
 	ticketHash := feeAddressRequest.TicketHash
 
 	// Respond early if we already have the fee tx for this ticket.
-	if ticket.FeeTxHex != "" {
+	if ticket.FeeTxStatus == database.FeeReceieved ||
+		ticket.FeeTxStatus == database.FeeBroadcast ||
+		ticket.FeeTxStatus == database.FeeConfirmed {
 		log.Warnf("Fee tx already received from %s: ticketHash=%s", c.ClientIP(), ticket.Hash)
 		sendError(errFeeAlreadyReceived, c)
 		return
@@ -173,7 +175,7 @@ func feeAddress(c *gin.Context) {
 		Confirmed:         confirmed,
 		FeeAmount:         int64(fee),
 		FeeExpiration:     expire,
-		// VotingKey and VoteChoices: set during payfee
+		FeeTxStatus:       database.NoFee,
 	}
 
 	err = db.InsertNewTicket(dbTicket)

--- a/webapi/templates/admin.html
+++ b/webapi/templates/admin.html
@@ -17,7 +17,7 @@
         <td>VotingWIF</td>
         <td>FeeTxHex</td>
         <td>FeeTxHash</td>
-        <td>FeeConfirmed</td>
+        <td>FeeTxStatus</td>
     </tr>
     {{ range .Tickets }}
     <tr>
@@ -25,14 +25,14 @@
         <td>{{ printf "%.10s" .CommitmentAddress }}...</td>
         <td>{{ printf "%d" .FeeAddressIndex }}</td>
         <td>{{ printf "%.10s" .FeeAddress }}...</td>
-        <td>{{ printf "%f" .FeeAmount }}</td>
+        <td>{{ printf "%d" .FeeAmount }}</td>
         <td>{{ printf "%d" .FeeExpiration }}</td>
         <td>{{ printf "%t" .Confirmed }}</td>
         <td>{{ printf "%.10s" .VoteChoices }}...</td>
         <td>{{ printf "%.10s" .VotingWIF }}...</td>
         <td>{{ printf "%.10s" .FeeTxHex }}...</td>
         <td>{{ printf "%.10s" .FeeTxHash }}...</td>
-        <td>{{ printf "%t" .FeeConfirmed }}</td>
+        <td>{{ printf "%s" .FeeTxStatus }}</td>
     </tr>
     {{ end }}
 </table>

--- a/webapi/ticketstatus.go
+++ b/webapi/ticketstatus.go
@@ -33,9 +33,7 @@ func ticketStatus(c *gin.Context) {
 		Timestamp:       time.Now().Unix(),
 		Request:         ticketStatusRequest,
 		TicketConfirmed: ticket.Confirmed,
-		FeeTxReceived:   ticket.FeeTxHex != "",
-		FeeTxBroadcast:  ticket.FeeTxHash != "",
-		FeeConfirmed:    ticket.FeeConfirmed,
+		FeeTxStatus:     string(ticket.FeeTxStatus),
 		FeeTxHash:       ticket.FeeTxHash,
 		VoteChoices:     ticket.VoteChoices,
 	}, c)

--- a/webapi/types.go
+++ b/webapi/types.go
@@ -1,11 +1,11 @@
 package webapi
 
 type vspInfoResponse struct {
-	Timestamp     int64   `json:"timestamp" binding:"required"`
-	PubKey        []byte  `json:"pubkey" binding:"required"`
-	FeePercentage float64 `json:"feepercentage" binding:"required"`
-	VspClosed     bool    `json:"vspclosed" binding:"required"`
-	Network       string  `json:"network" binding:"required"`
+	Timestamp     int64   `json:"timestamp"`
+	PubKey        []byte  `json:"pubkey"`
+	FeePercentage float64 `json:"feepercentage"`
+	VspClosed     bool    `json:"vspclosed"`
+	Network       string  `json:"network"`
 }
 
 type FeeAddressRequest struct {
@@ -14,11 +14,11 @@ type FeeAddressRequest struct {
 }
 
 type feeAddressResponse struct {
-	Timestamp  int64             `json:"timestamp" binding:"required"`
-	FeeAddress string            `json:"feeaddress" binding:"required"`
-	FeeAmount  int64             `json:"feeamount" binding:"required"`
-	Expiration int64             `json:"expiration" binding:"required"`
-	Request    FeeAddressRequest `json:"request" binding:"required"`
+	Timestamp  int64             `json:"timestamp"`
+	FeeAddress string            `json:"feeaddress"`
+	FeeAmount  int64             `json:"feeamount"`
+	Expiration int64             `json:"expiration"`
+	Request    FeeAddressRequest `json:"request"`
 }
 
 type PayFeeRequest struct {
@@ -30,8 +30,8 @@ type PayFeeRequest struct {
 }
 
 type payFeeResponse struct {
-	Timestamp int64         `json:"timestamp" binding:"required"`
-	Request   PayFeeRequest `json:"request" binding:"required"`
+	Timestamp int64         `json:"timestamp"`
+	Request   PayFeeRequest `json:"request"`
 }
 
 type SetVoteChoicesRequest struct {
@@ -41,8 +41,8 @@ type SetVoteChoicesRequest struct {
 }
 
 type setVoteChoicesResponse struct {
-	Timestamp int64                 `json:"timestamp" binding:"required"`
-	Request   SetVoteChoicesRequest `json:"request" binding:"required"`
+	Timestamp int64                 `json:"timestamp"`
+	Request   SetVoteChoicesRequest `json:"request"`
 }
 
 type TicketStatusRequest struct {
@@ -51,12 +51,10 @@ type TicketStatusRequest struct {
 }
 
 type ticketStatusResponse struct {
-	Timestamp       int64               `json:"timestamp" binding:"required"`
-	TicketConfirmed bool                `json:"ticketconfirmed" binding:"required"`
-	FeeTxReceived   bool                `json:"feetxreceived" binding:"required"`
-	FeeTxBroadcast  bool                `json:"feetxbroadcast" binding:"required"`
-	FeeConfirmed    bool                `json:"feeconfirmed" binding:"required"`
-	FeeTxHash       string              `json:"feetxhash" binding:"required"`
-	VoteChoices     map[string]string   `json:"votechoices" binding:"required"`
-	Request         TicketStatusRequest `json:"request" binding:"required"`
+	Timestamp       int64               `json:"timestamp"`
+	TicketConfirmed bool                `json:"ticketconfirmed"`
+	FeeTxStatus     string              `json:"feetxstatus"`
+	FeeTxHash       string              `json:"feetxhash"`
+	VoteChoices     map[string]string   `json:"votechoices"`
+	Request         TicketStatusRequest `json:"request"`
 }


### PR DESCRIPTION
- Fee tx status is now tracked using a dedicated field, with values none/received/broadcast/confirmed/error.
- Fee tx hex and hash are now both set in /payfee. The absense of txhash is no longer used to determine if a fee tx has been broadcast or not.
- setvotechoices can no longer be called before a fee is received.
- Remove `binding:required` from response types. It has no effect on responses, it is only needed on request types which are validated by gin.

Closes #120 