### PR TITLE
Defer closing RPC clients and database

### DIFF
--- a/background/background.go
+++ b/background/background.go
@@ -214,7 +214,7 @@ func connectNotifier(dcrdWithNotifs rpc.DcrdConnect) error {
 	// notifier is closed.
 	select {
 	case <-ctx.Done():
-		return ctx.Err()
+		return nil
 	case <-notifierClosed:
 		return nil
 	}
@@ -240,14 +240,14 @@ func Start(c context.Context, vdb *database.VspDatabase, drpc rpc.DcrdConnect,
 			err := connectNotifier(dcrdWithNotif)
 			if err != nil {
 				log.Errorf("dcrd connect error: %v", err)
+			}
 
-				// If context is done (vspd is shutting down), return,
-				// otherwise wait 15 seconds and try to reconnect.
-				select {
-				case <-ctx.Done():
-					return
-				case <-time.After(15 * time.Second):
-				}
+			// If context is done (vspd is shutting down), return,
+			// otherwise wait 15 seconds and try to reconnect.
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(15 * time.Second):
 			}
 
 		}

--- a/main.go
+++ b/main.go
@@ -91,7 +91,7 @@ func run(ctx context.Context) error {
 
 	// Start background process which will continually attempt to reconnect to
 	// dcrd if the connection drops.
-	background.Start(ctx, db, dcrd, dcrdWithNotifs, wallets, cfg.netParams.Params)
+	background.Start(ctx, &shutdownWg, db, dcrd, dcrdWithNotifs, wallets, cfg.netParams.Params)
 
 	// Wait for shutdown tasks to complete before running deferred tasks and
 	// returning.

--- a/main.go
+++ b/main.go
@@ -56,6 +56,7 @@ func run(ctx context.Context) error {
 		shutdownWg.Wait()
 		return err
 	}
+	defer db.Close()
 
 	// Create RPC client for local dcrd instance (used for broadcasting and
 	// checking the status of fee transactions).
@@ -91,7 +92,8 @@ func run(ctx context.Context) error {
 	// dcrd if the connection drops.
 	background.Start(ctx, db, dcrd, dcrdWithNotifs, wallets, cfg.netParams.Params)
 
-	// Wait for shutdown tasks to complete before returning.
+	// Wait for shutdown tasks to complete before running deferred tasks and
+	// returning.
 	shutdownWg.Wait()
 
 	return ctx.Err()

--- a/main.go
+++ b/main.go
@@ -60,12 +60,12 @@ func run(ctx context.Context) error {
 
 	// Create RPC client for local dcrd instance (used for broadcasting and
 	// checking the status of fee transactions).
-	dcrd := rpc.SetupDcrd(ctx, &shutdownWg, cfg.DcrdUser, cfg.DcrdPass,
-		cfg.DcrdHost, cfg.dcrdCert, nil)
+	dcrd := rpc.SetupDcrd(cfg.DcrdUser, cfg.DcrdPass, cfg.DcrdHost, cfg.dcrdCert, nil)
+	defer dcrd.Close()
 
 	// Create RPC client for remote dcrwallet instance (used for voting).
-	wallets := rpc.SetupWallet(ctx, &shutdownWg, cfg.WalletUser, cfg.WalletPass,
-		cfg.WalletHosts, cfg.walletCert)
+	wallets := rpc.SetupWallet(cfg.WalletUser, cfg.WalletPass, cfg.WalletHosts, cfg.walletCert)
+	defer wallets.Close()
 
 	// Create and start webapi server.
 	apiCfg := webapi.Config{
@@ -85,8 +85,9 @@ func run(ctx context.Context) error {
 	}
 
 	// Create a dcrd client with a blockconnected notification handler.
-	dcrdWithNotifs := rpc.SetupDcrd(ctx, &shutdownWg, cfg.DcrdUser, cfg.DcrdPass,
+	dcrdWithNotifs := rpc.SetupDcrd(cfg.DcrdUser, cfg.DcrdPass,
 		cfg.DcrdHost, cfg.dcrdCert, &background.NotificationHandler{})
+	defer dcrdWithNotifs.Close()
 
 	// Start background process which will continually attempt to reconnect to
 	// dcrd if the connection drops.

--- a/webapi/webapi.go
+++ b/webapi/webapi.go
@@ -107,7 +107,7 @@ func Start(ctx context.Context, requestShutdownChan chan struct{}, shutdownWg *s
 
 		log.Debug("Stopping webserver...")
 		// Give the webserver 5 seconds to finish what it is doing.
-		timeoutCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		timeoutCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()
 		if err := srv.Shutdown(timeoutCtx); err != nil {
 			log.Errorf("Failed to stop webserver cleanly: %v", err)


### PR DESCRIPTION
Previously all of the shutdown tasks were running concurrently, which meant the DB or the RPC clients could be closed while the webserver or background handler still needed them.

With this PR, the DB and RPC clients are not closed until webserver and background handler have finished what they are doing.
