### PR TITLE
Dont use byte slices outside of db tx.

### DIFF
--- a/database/database.go
+++ b/database/database.go
@@ -196,7 +196,13 @@ func (vdb *VspDatabase) KeyPair() (ed25519.PrivateKey, ed25519.PublicKey, error)
 	err := vdb.db.View(func(tx *bolt.Tx) error {
 		vspBkt := tx.Bucket(vspBktK)
 
-		seed = vspBkt.Get(privateKeyK)
+		s := vspBkt.Get(privateKeyK)
+
+		// Byte slices returned from Bolt are only valid during a transaction.
+		// Need to make a copy.
+		seed = make([]byte, len(s))
+		copy(seed, s)
+
 		if seed == nil {
 			// should not happen
 			return fmt.Errorf("no private key found")
@@ -242,7 +248,12 @@ func (vdb *VspDatabase) GetCookieSecret() ([]byte, error) {
 	err := vdb.db.View(func(tx *bolt.Tx) error {
 		vspBkt := tx.Bucket(vspBktK)
 
-		cookieSecret = vspBkt.Get(cookieSecretK)
+		cs := vspBkt.Get(cookieSecretK)
+
+		// Byte slices returned from Bolt are only valid during a transaction.
+		// Need to make a copy.
+		cookieSecret = make([]byte, len(cs))
+		copy(cookieSecret, cs)
 
 		return nil
 	})


### PR DESCRIPTION
I saw a panic (pasted below) while simultaneously using the admin screen and hitting the API with /feeaddress and /payfee requests.

It looks very similar to decred/dcrpool#92 which was fixed by decred/dcrpool#123

I haven't been able to recreate the panic so I'm not 100% sure if this fix works, but we need the changes in this PR anyway.

```
unexpected fault address 0x7f410860707c
fatal error: fault
[signal SIGSEGV: segmentation violation code=0x1 addr=0x7f410860707c pc=0x4669c7]

goroutine 574 [running]:
runtime.throw(0xb3aa77, 0x5)
        /usr/lib/go-1.14/src/runtime/panic.go:1116 +0x72 fp=0xc00065f560 sp=0xc00065f530 pc=0x434fb2
runtime.sigpanic()
        /usr/lib/go-1.14/src/runtime/signal_unix.go:702 +0x3cc fp=0xc00065f590 sp=0xc00065f560 pc=0x44afbc
runtime.memmove(0xc00075ad00, 0x7f410860707c, 0x20)
        /usr/lib/go-1.14/src/runtime/memmove_amd64.s:181 +0x147 fp=0xc00065f598 sp=0xc00065f590 pc=0x4669c7
crypto/hmac.New(0xcb4b88, 0x7f410860707c, 0x20, 0x20, 0x1, 0x1)
        /usr/lib/go-1.14/src/crypto/hmac/hmac.go:83 +0x276 fp=0xc00065f5e8 sp=0xc00065f598 pc=0x5ae6b6
github.com/gorilla/securecookie.(*SecureCookie).Decode(0xc0006da7e0, 0xb40c42, 0xc, 0xc00053400d, 0x8c, 0xa36000, 0xc000174880, 0xc0000100c0, 0xc00065f7a0)
        /home/jholdstock/code/gopath/pkg/mod/github.com/gorilla/securecookie@v1.1.1/securecookie.go:325 +0x17a fp=0xc00065f720 sp=0xc00065f5e8 pc=0x9d21aa
github.com/gorilla/securecookie.DecodeMulti(0xb40c42, 0xc, 0xc00053400d, 0x8c, 0xa36000, 0xc000174880, 0xc0005998f0, 0x1, 0x1, 0x4f4d90, ...)
        /home/jholdstock/code/gopath/pkg/mod/github.com/gorilla/securecookie@v1.1.1/securecookie.go:591 +0xe2 fp=0xc00065f7b0 sp=0xc00065f720 pc=0x9d3ad2
github.com/gorilla/sessions.(*CookieStore).New(0xc000119f20, 0xc000400400, 0xb40c42, 0xc, 0x122b4e0, 0xc0006a8f00, 0x6)
        /home/jholdstock/code/gopath/pkg/mod/github.com/gorilla/sessions@v1.2.0/store.go:92 +0x21a fp=0xc00065f848 sp=0xc00065f7b0 pc=0x9d61aa
github.com/gorilla/sessions.(*Registry).Get(0xc00025c380, 0xd94660, 0xc000119f20, 0xb40c42, 0xc, 0xc00065f920, 0x454a87, 0xe4ee23e2c9b)
        /home/jholdstock/code/gopath/pkg/mod/github.com/gorilla/sessions@v1.2.0/sessions.go:139 +0x11a fp=0xc00065f8b8 sp=0xc00065f848 pc=0x9d52ea
github.com/gorilla/sessions.(*CookieStore).Get(0xc000119f20, 0xc000400400, 0xb40c42, 0xc, 0x4300a9, 0x7f41090ba948, 0xe4ee23e2c9b)
        /home/jholdstock/code/gopath/pkg/mod/github.com/gorilla/sessions@v1.2.0/store.go:77 +0x63 fp=0xc00065f908 sp=0xc00065f8b8 pc=0x9d5f53
github.com/decred/vspd/webapi.withSession.func1(0xc0005f60f0)
        /home/jholdstock/code/jholdstock/vspd/webapi/middleware.go:23 +0x67 fp=0xc00065f9a8 sp=0xc00065f908 pc=0x9e1797
github.com/gin-gonic/gin.(*Context).Next(0xc0005f60f0)
        /home/jholdstock/code/gopath/pkg/mod/github.com/gin-gonic/gin@v1.6.3/context.go:161 +0x3b fp=0xc00065f9c8 sp=0xc00065f9a8 pc=0x9bb69b
github.com/gin-gonic/gin.RecoveryWithWriter.func1(0xc0005f60f0)
        /home/jholdstock/code/gopath/pkg/mod/github.com/gin-gonic/gin@v1.6.3/recovery.go:83 +0x60 fp=0xc00065fa08 sp=0xc00065f9c8 pc=0x9cea70
github.com/gin-gonic/gin.(*Context).Next(0xc0005f60f0)
        /home/jholdstock/code/gopath/pkg/mod/github.com/gin-gonic/gin@v1.6.3/context.go:161 +0x3b fp=0xc00065fa28 sp=0xc00065fa08 pc=0x9bb69b
github.com/gin-gonic/gin.(*Engine).handleHTTPRequest(0xc0000d0140, 0xc0005f60f0)
        /home/jholdstock/code/gopath/pkg/mod/github.com/gin-gonic/gin@v1.6.3/gin.go:409 +0x666 fp=0xc00065fbb0 sp=0xc00065fa28 pc=0x9c5146
github.com/gin-gonic/gin.(*Engine).ServeHTTP(0xc0000d0140, 0xd949a0, 0xc00053ee00, 0xc000400400)
        /home/jholdstock/code/gopath/pkg/mod/github.com/gin-gonic/gin@v1.6.3/gin.go:367 +0x14d fp=0xc00065fbe8 sp=0xc00065fbb0 pc=0x9c485d
net/http.serverHandler.ServeHTTP(0xc0006f08c0, 0xd949a0, 0xc00053ee00, 0xc000400400)
        /usr/lib/go-1.14/src/net/http/server.go:2807 +0xa3 fp=0xc00065fc18 sp=0xc00065fbe8 pc=0x75cbb3
net/http.(*conn).serve(0xc0000b65a0, 0xd96c60, 0xc00007d840)
        /usr/lib/go-1.14/src/net/http/server.go:1895 +0x86c fp=0xc00065ffc8 sp=0xc00065fc18 pc=0x75852c
runtime.goexit()
        /usr/lib/go-1.14/src/runtime/asm_amd64.s:1373 +0x1 fp=0xc00065ffd0 sp=0xc00065ffc8 pc=0x4656b1
created by net/http.(*Server).Serve
        /usr/lib/go-1.14/src/net/http/server.go:2933 +0x35c

goroutine 1 [semacquire, 32 minutes]:
sync.runtime_Semacquire(0xc00010e3b8)
        /usr/lib/go-1.14/src/runtime/sema.go:56 +0x42
sync.(*WaitGroup).Wait(0xc00010e3b0)
        /usr/lib/go-1.14/src/sync/waitgroup.go:130 +0x64
main.run(0xd96c60, 0xc00007c000, 0x0, 0x0)
        /home/jholdstock/code/jholdstock/vspd/main.go:99 +0x94e
main.main()
        /home/jholdstock/code/jholdstock/vspd/main.go:23 +0x81

goroutine 21 [syscall, 32 minutes]:
os/signal.signal_recv(0x0)
        /usr/lib/go-1.14/src/runtime/sigqueue.go:147 +0x9c
os/signal.loop()
        /usr/lib/go-1.14/src/os/signal/signal_unix.go:23 +0x22
created by os/signal.Notify.func1
        /usr/lib/go-1.14/src/os/signal/signal.go:127 +0x44

goroutine 13 [chan receive, 32 minutes]:
main.withShutdownCancel.func1(0xc000078770)
        /home/jholdstock/code/jholdstock/vspd/signal.go:32 +0x36
created by main.withShutdownCancel
        /home/jholdstock/code/jholdstock/vspd/signal.go:31 +0x6b

goroutine 14 [select, 32 minutes]:
main.shutdownListener()
        /home/jholdstock/code/jholdstock/vspd/signal.go:52 +0x104
created by main.main
        /home/jholdstock/code/jholdstock/vspd/main.go:20 +0x69

goroutine 15 [select, 3 minutes]:
github.com/decred/vspd/database.Open.func1(0x29e8d60800, 0xc0006e6000, 0xd96c60, 0xc00007c000, 0xc00010e3b0)
        /home/jholdstock/code/jholdstock/vspd/database/database.go:163 +0xe4
created by github.com/decred/vspd/database.Open
        /home/jholdstock/code/jholdstock/vspd/database/database.go:160 +0x254

goroutine 39 [IO wait, 1 minutes]:
internal/poll.runtime_pollWait(0x7f41090bada0, 0x72, 0xffffffffffffffff)
        /usr/lib/go-1.14/src/runtime/netpoll.go:203 +0x55
internal/poll.(*pollDesc).wait(0xc00068a698, 0x72, 0x3f00, 0x3fd6, 0xffffffffffffffff)
        /usr/lib/go-1.14/src/internal/poll/fd_poll_runtime.go:87 +0x45
internal/poll.(*pollDesc).waitRead(...)
        /usr/lib/go-1.14/src/internal/poll/fd_poll_runtime.go:92
internal/poll.(*FD).Read(0xc00068a680, 0xc0005e0000, 0x3fd6, 0x3fd6, 0x0, 0x0, 0x0)
        /usr/lib/go-1.14/src/internal/poll/fd_unix.go:169 +0x19b
net.(*netFD).Read(0xc00068a680, 0xc0005e0000, 0x3fd6, 0x3fd6, 0x203000, 0x6a0780, 0xc00050cbb8)
        /usr/lib/go-1.14/src/net/fd_unix.go:202 +0x4f
net.(*conn).Read(0xc00059a0b8, 0xc0005e0000, 0x3fd6, 0x3fd6, 0x0, 0x0, 0x0)
        /usr/lib/go-1.14/src/net/net.go:184 +0x8e
crypto/tls.(*atLeastReader).Read(0xc000844060, 0xc0005e0000, 0x3fd6, 0x3fd6, 0x13, 0x3fd1, 0xc000659980)
        /usr/lib/go-1.14/src/crypto/tls/conn.go:760 +0x60
bytes.(*Buffer).ReadFrom(0xc00050ccd8, 0xd880e0, 0xc000844060, 0x40bfc5, 0xa8b0c0, 0xb11a40)
        /usr/lib/go-1.14/src/bytes/buffer.go:204 +0xb1
crypto/tls.(*Conn).readFromUntil(0xc00050ca80, 0xd88820, 0xc00059a0b8, 0x5, 0xc00059a0b8, 0x2)
        /usr/lib/go-1.14/src/crypto/tls/conn.go:782 +0xec
crypto/tls.(*Conn).readRecordOrCCS(0xc00050ca80, 0x0, 0x0, 0xe34b726dd8a)
        /usr/lib/go-1.14/src/crypto/tls/conn.go:589 +0x115
crypto/tls.(*Conn).readRecord(...)
        /usr/lib/go-1.14/src/crypto/tls/conn.go:557
crypto/tls.(*Conn).Read(0xc00050ca80, 0xc0008dd000, 0x1000, 0x1000, 0x0, 0x0, 0x0)
        /usr/lib/go-1.14/src/crypto/tls/conn.go:1233 +0x15b
bufio.(*Reader).fill(0xc000142660)
        /usr/lib/go-1.14/src/bufio/bufio.go:100 +0x103
bufio.(*Reader).Peek(0xc000142660, 0x2, 0xc000034200, 0xc0006df080, 0x11fe320, 0xb2ed60, 0xc000844040)
        /usr/lib/go-1.14/src/bufio/bufio.go:138 +0x4f
github.com/gorilla/websocket.(*Conn).read(0xc0006df080, 0x2, 0x0, 0x0, 0x0, 0x0, 0x0)
        /home/jholdstock/code/gopath/pkg/mod/github.com/gorilla/websocket@v1.4.1/conn.go:370 +0x40
github.com/gorilla/websocket.(*Conn).advanceFrame(0xc0006df080, 0xa, 0x0, 0x0)
        /home/jholdstock/code/gopath/pkg/mod/github.com/gorilla/websocket@v1.4.1/conn.go:798 +0x5c
github.com/gorilla/websocket.(*Conn).NextReader(0xc0006df080, 0x45f6c0, 0xc00007e6c0, 0xc000659ea8, 0xc000659ea8, 0x40e8e8)
        /home/jholdstock/code/gopath/pkg/mod/github.com/gorilla/websocket@v1.4.1/conn.go:980 +0x8f
github.com/gorilla/websocket.(*Conn).ReadJSON(0xc0006df080, 0xa3a480, 0xc000098640, 0x2, 0xb446d0)
        /home/jholdstock/code/gopath/pkg/mod/github.com/gorilla/websocket@v1.4.1/json.go:50 +0x2f
github.com/jrick/wsrpc/v2.(*Client).in(0xc000034200, 0xd96d20, 0xc000689f50)
        /home/jholdstock/code/gopath/pkg/mod/github.com/jrick/wsrpc/v2@v2.3.3/rpc.go:368 +0x20c
created by github.com/jrick/wsrpc/v2.Dial
        /home/jholdstock/code/gopath/pkg/mod/github.com/jrick/wsrpc/v2@v2.3.3/rpc.go:244 +0x38a

goroutine 71 [chan receive, 32 minutes]:
github.com/decred/vspd/webapi.Start.func1(0xd96c60, 0xc00007c000, 0xc0006f08c0, 0xc00010e3b0)
        /home/jholdstock/code/jholdstock/vspd/webapi/webapi.go:107 +0x5d
created by github.com/decred/vspd/webapi.Start
        /home/jholdstock/code/jholdstock/vspd/webapi/webapi.go:105 +0x919

goroutine 72 [IO wait]:
internal/poll.runtime_pollWait(0x7f41090bb040, 0x72, 0x0)
        /usr/lib/go-1.14/src/runtime/netpoll.go:203 +0x55
internal/poll.(*pollDesc).wait(0xc000034618, 0x72, 0x0, 0x0, 0xb3c7b5)
        /usr/lib/go-1.14/src/internal/poll/fd_poll_runtime.go:87 +0x45
internal/poll.(*pollDesc).waitRead(...)
        /usr/lib/go-1.14/src/internal/poll/fd_poll_runtime.go:92
internal/poll.(*FD).Accept(0xc000034600, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0)
        /usr/lib/go-1.14/src/internal/poll/fd_unix.go:384 +0x1d4
net.(*netFD).accept(0xc000034600, 0xd546286a7eedf8f4, 0x0, 0xd546286a7eedf8f4)
        /usr/lib/go-1.14/src/net/fd_unix.go:238 +0x42
net.(*TCPListener).accept(0xc000119a00, 0x5ee8ae2e, 0xc000075e10, 0x4c17d6)
        /usr/lib/go-1.14/src/net/tcpsock_posix.go:139 +0x32
net.(*TCPListener).Accept(0xc000119a00, 0xc000075e60, 0x18, 0xc00060af00, 0x75d05c)
        /usr/lib/go-1.14/src/net/tcpsock.go:261 +0x64
net/http.(*Server).Serve(0xc0006f08c0, 0xd946e0, 0xc000119a00, 0x0, 0x0)
        /usr/lib/go-1.14/src/net/http/server.go:2901 +0x25d
github.com/decred/vspd/webapi.Start.func2(0xc0006f08c0, 0xd946e0, 0xc000119a00, 0xc0005989b0, 0xc000030180)
        /home/jholdstock/code/jholdstock/vspd/webapi/webapi.go:123 +0x43
created by github.com/decred/vspd/webapi.Start
        /home/jholdstock/code/jholdstock/vspd/webapi/webapi.go:122 +0x96f

goroutine 73 [select, 3 minutes]:
github.com/decred/vspd/webapi.Start.func3(0x45d964b800, 0xd96c60, 0xc00007c000, 0xc00010e3b0, 0xc0005989b0)
        /home/jholdstock/code/jholdstock/vspd/webapi/webapi.go:144 +0xe4
created by github.com/decred/vspd/webapi.Start
        /home/jholdstock/code/jholdstock/vspd/webapi/webapi.go:141 +0xa07

goroutine 82 [IO wait, 1 minutes]:
internal/poll.runtime_pollWait(0x7f41090babe0, 0x72, 0xffffffffffffffff)
        /usr/lib/go-1.14/src/runtime/netpoll.go:203 +0x55
internal/poll.(*pollDesc).wait(0xc00068a918, 0x72, 0x3800, 0x3866, 0xffffffffffffffff)
        /usr/lib/go-1.14/src/internal/poll/fd_poll_runtime.go:87 +0x45
internal/poll.(*pollDesc).waitRead(...)
        /usr/lib/go-1.14/src/internal/poll/fd_poll_runtime.go:92
internal/poll.(*FD).Read(0xc00068a900, 0xc000310000, 0x3866, 0x3866, 0x0, 0x0, 0x0)
        /usr/lib/go-1.14/src/internal/poll/fd_unix.go:169 +0x19b
net.(*netFD).Read(0xc00068a900, 0xc000310000, 0x3866, 0x3866, 0x203000, 0x6a0780, 0xc00050cf38)
        /usr/lib/go-1.14/src/net/fd_unix.go:202 +0x4f
net.(*conn).Read(0xc00059a0f0, 0xc000310000, 0x3866, 0x3866, 0x0, 0x0, 0x0)
        /usr/lib/go-1.14/src/net/net.go:184 +0x8e
crypto/tls.(*atLeastReader).Read(0xc0008441a0, 0xc000310000, 0x3866, 0x3866, 0x13, 0x3861, 0xc0005cd980)
        /usr/lib/go-1.14/src/crypto/tls/conn.go:760 +0x60
bytes.(*Buffer).ReadFrom(0xc00050d058, 0xd880e0, 0xc0008441a0, 0x40bfc5, 0xa8b0c0, 0xb11a40)
        /usr/lib/go-1.14/src/bytes/buffer.go:204 +0xb1
crypto/tls.(*Conn).readFromUntil(0xc00050ce00, 0xd88820, 0xc00059a0f0, 0x5, 0xc00059a0f0, 0x2)
        /usr/lib/go-1.14/src/crypto/tls/conn.go:782 +0xec
crypto/tls.(*Conn).readRecordOrCCS(0xc00050ce00, 0x0, 0x0, 0xe34b773b589)
        /usr/lib/go-1.14/src/crypto/tls/conn.go:589 +0x115
crypto/tls.(*Conn).readRecord(...)
        /usr/lib/go-1.14/src/crypto/tls/conn.go:557
crypto/tls.(*Conn).Read(0xc00050ce00, 0xc00014f000, 0x1000, 0x1000, 0x0, 0x0, 0x0)
        /usr/lib/go-1.14/src/crypto/tls/conn.go:1233 +0x15b
bufio.(*Reader).fill(0xc000286540)
        /usr/lib/go-1.14/src/bufio/bufio.go:100 +0x103
bufio.(*Reader).Peek(0xc000286540, 0x2, 0xc00068a980, 0xc0001642c0, 0x11fe320, 0xb2ed60, 0xc000844180)
        /usr/lib/go-1.14/src/bufio/bufio.go:138 +0x4f
github.com/gorilla/websocket.(*Conn).read(0xc0001642c0, 0x2, 0x0, 0x0, 0x0, 0x0, 0x0)
        /home/jholdstock/code/gopath/pkg/mod/github.com/gorilla/websocket@v1.4.1/conn.go:370 +0x40
github.com/gorilla/websocket.(*Conn).advanceFrame(0xc0001642c0, 0xa, 0x0, 0x0)
        /home/jholdstock/code/gopath/pkg/mod/github.com/gorilla/websocket@v1.4.1/conn.go:798 +0x5c
github.com/gorilla/websocket.(*Conn).NextReader(0xc0001642c0, 0x45f6c0, 0xc00007e720, 0xc0005cdea8, 0xc0005cdea8, 0x40e8e8)
        /home/jholdstock/code/gopath/pkg/mod/github.com/gorilla/websocket@v1.4.1/conn.go:980 +0x8f
github.com/gorilla/websocket.(*Conn).ReadJSON(0xc0001642c0, 0xa3a480, 0xc0000986e0, 0x2, 0xb446d0)
        /home/jholdstock/code/gopath/pkg/mod/github.com/gorilla/websocket@v1.4.1/json.go:50 +0x2f
github.com/jrick/wsrpc/v2.(*Client).in(0xc00068a980, 0xd96d20, 0xc000147200)
        /home/jholdstock/code/gopath/pkg/mod/github.com/jrick/wsrpc/v2@v2.3.3/rpc.go:368 +0x20c
created by github.com/jrick/wsrpc/v2.Dial
        /home/jholdstock/code/gopath/pkg/mod/github.com/jrick/wsrpc/v2@v2.3.3/rpc.go:244 +0x38a

goroutine 40 [select, 1 minutes]:
github.com/jrick/wsrpc/v2.(*Client).out(0xc000034200, 0xd96d20, 0xc0001f8660, 0xc0006f8050)
        /home/jholdstock/code/gopath/pkg/mod/github.com/jrick/wsrpc/v2@v2.3.3/rpc.go:313 +0x247
created by github.com/jrick/wsrpc/v2.Dial
        /home/jholdstock/code/gopath/pkg/mod/github.com/jrick/wsrpc/v2@v2.3.3/rpc.go:245 +0x3d3

goroutine 41 [IO wait, 1 minutes]:
internal/poll.runtime_pollWait(0x7f41090bacc0, 0x72, 0xffffffffffffffff)
        /usr/lib/go-1.14/src/runtime/netpoll.go:203 +0x55
internal/poll.(*pollDesc).wait(0xc00011e598, 0x72, 0x3d00, 0x3de4, 0xffffffffffffffff)
        /usr/lib/go-1.14/src/internal/poll/fd_poll_runtime.go:87 +0x45
internal/poll.(*pollDesc).waitRead(...)
        /usr/lib/go-1.14/src/internal/poll/fd_poll_runtime.go:92
internal/poll.(*FD).Read(0xc00011e580, 0xc000352000, 0x3de4, 0x3de4, 0x0, 0x0, 0x0)
        /usr/lib/go-1.14/src/internal/poll/fd_unix.go:169 +0x19b
net.(*netFD).Read(0xc00011e580, 0xc000352000, 0x3de4, 0x3de4, 0x203000, 0x6a0780, 0xc0006099b8)
        /usr/lib/go-1.14/src/net/fd_unix.go:202 +0x4f
net.(*conn).Read(0xc0005180c8, 0xc000352000, 0x3de4, 0x3de4, 0x0, 0x0, 0x0)
        /usr/lib/go-1.14/src/net/net.go:184 +0x8e
crypto/tls.(*atLeastReader).Read(0xc000844100, 0xc000352000, 0x3de4, 0x3de4, 0x13, 0x3ddf, 0xc000857980)
        /usr/lib/go-1.14/src/crypto/tls/conn.go:760 +0x60
bytes.(*Buffer).ReadFrom(0xc000609ad8, 0xd880e0, 0xc000844100, 0x40bfc5, 0xa8b0c0, 0xb11a40)
        /usr/lib/go-1.14/src/bytes/buffer.go:204 +0xb1
crypto/tls.(*Conn).readFromUntil(0xc000609880, 0xd88820, 0xc0005180c8, 0x5, 0xc0005180c8, 0x2)
        /usr/lib/go-1.14/src/crypto/tls/conn.go:782 +0xec
crypto/tls.(*Conn).readRecordOrCCS(0xc000609880, 0x0, 0x0, 0xe34b74d37d4)
        /usr/lib/go-1.14/src/crypto/tls/conn.go:589 +0x115
crypto/tls.(*Conn).readRecord(...)
        /usr/lib/go-1.14/src/crypto/tls/conn.go:557
crypto/tls.(*Conn).Read(0xc000609880, 0xc0001f0000, 0x1000, 0x1000, 0x0, 0x0, 0x0)
        /usr/lib/go-1.14/src/crypto/tls/conn.go:1233 +0x15b
bufio.(*Reader).fill(0xc0001cf560)
        /usr/lib/go-1.14/src/bufio/bufio.go:100 +0x103
bufio.(*Reader).Peek(0xc0001cf560, 0x2, 0xc000034300, 0xc0006f7b80, 0x11fe320, 0xb2ed60, 0xc0008440e0)
        /usr/lib/go-1.14/src/bufio/bufio.go:138 +0x4f
github.com/gorilla/websocket.(*Conn).read(0xc0006f7b80, 0x2, 0x0, 0x0, 0x0, 0x0, 0x0)
        /home/jholdstock/code/gopath/pkg/mod/github.com/gorilla/websocket@v1.4.1/conn.go:370 +0x40
github.com/gorilla/websocket.(*Conn).advanceFrame(0xc0006f7b80, 0xa, 0x0, 0x0)
        /home/jholdstock/code/gopath/pkg/mod/github.com/gorilla/websocket@v1.4.1/conn.go:798 +0x5c
github.com/gorilla/websocket.(*Conn).NextReader(0xc0006f7b80, 0x45f6c0, 0xc00007e6c0, 0xc000857ea8, 0xc000857ea8, 0x40e8e8)
        /home/jholdstock/code/gopath/pkg/mod/github.com/gorilla/websocket@v1.4.1/conn.go:980 +0x8f
github.com/gorilla/websocket.(*Conn).ReadJSON(0xc0006f7b80, 0xa3a480, 0xc0000985f0, 0x2, 0xb446d0)
        /home/jholdstock/code/gopath/pkg/mod/github.com/gorilla/websocket@v1.4.1/json.go:50 +0x2f
github.com/jrick/wsrpc/v2.(*Client).in(0xc000034300, 0xd96d20, 0xc000112ff0)
        /home/jholdstock/code/gopath/pkg/mod/github.com/jrick/wsrpc/v2@v2.3.3/rpc.go:368 +0x20c
created by github.com/jrick/wsrpc/v2.Dial
        /home/jholdstock/code/gopath/pkg/mod/github.com/jrick/wsrpc/v2@v2.3.3/rpc.go:244 +0x38a

goroutine 42 [select, 1 minutes]:
github.com/jrick/wsrpc/v2.(*Client).out(0xc000034300, 0xd96d20, 0xc0001f8960, 0xc0006f80f0)
        /home/jholdstock/code/gopath/pkg/mod/github.com/jrick/wsrpc/v2@v2.3.3/rpc.go:313 +0x247
created by github.com/jrick/wsrpc/v2.Dial
        /home/jholdstock/code/gopath/pkg/mod/github.com/jrick/wsrpc/v2@v2.3.3/rpc.go:245 +0x3d3

goroutine 83 [select, 1 minutes]:
github.com/jrick/wsrpc/v2.(*Client).out(0xc00068a980, 0xd96d20, 0xc0001479b0, 0xc000174370)
        /home/jholdstock/code/gopath/pkg/mod/github.com/jrick/wsrpc/v2@v2.3.3/rpc.go:313 +0x247
created by github.com/jrick/wsrpc/v2.Dial
        /home/jholdstock/code/gopath/pkg/mod/github.com/jrick/wsrpc/v2@v2.3.3/rpc.go:245 +0x3d3

goroutine 43 [select, 3 minutes]:
github.com/decred/vspd/background.Start.func1()
        /home/jholdstock/code/jholdstock/vspd/background/background.go:317 +0xd9
created by github.com/decred/vspd/background.Start
        /home/jholdstock/code/jholdstock/vspd/background/background.go:314 +0xc5

goroutine 44 [select, 31 minutes]:
github.com/decred/vspd/background.connectNotifier(0xc00007d8c0, 0xc000072f58, 0x2)
        /home/jholdstock/code/jholdstock/vspd/background/background.go:286 +0x1f4
github.com/decred/vspd/background.Start.func2(0xc00007d8c0)
        /home/jholdstock/code/jholdstock/vspd/background/background.go:331 +0x40
created by github.com/decred/vspd/background.Start
        /home/jholdstock/code/jholdstock/vspd/background/background.go:329 +0xe7

goroutine 390 [IO wait]:
internal/poll.runtime_pollWait(0x7f41090bae80, 0x72, 0xffffffffffffffff)
        /usr/lib/go-1.14/src/runtime/netpoll.go:203 +0x55
internal/poll.(*pollDesc).wait(0xc00068a018, 0x72, 0x1000, 0x1000, 0xffffffffffffffff)
        /usr/lib/go-1.14/src/internal/poll/fd_poll_runtime.go:87 +0x45
internal/poll.(*pollDesc).waitRead(...)
        /usr/lib/go-1.14/src/internal/poll/fd_poll_runtime.go:92
internal/poll.(*FD).Read(0xc00068a000, 0xc000548000, 0x1000, 0x1000, 0x0, 0x0, 0x0)
        /usr/lib/go-1.14/src/internal/poll/fd_unix.go:169 +0x19b
net.(*netFD).Read(0xc00068a000, 0xc000548000, 0x1000, 0x1000, 0x4c131a, 0xe4eb613ae99, 0x0)
        /usr/lib/go-1.14/src/net/fd_unix.go:202 +0x4f
net.(*conn).Read(0xc000010008, 0xc000548000, 0x1000, 0x1000, 0x0, 0x0, 0x0)
        /usr/lib/go-1.14/src/net/net.go:184 +0x8e
net/http.(*connReader).Read(0xc0006882d0, 0xc000548000, 0x1000, 0x1000, 0xbfb2496ccba04a8a, 0x1cc3d703f24, 0x11fe320)
        /usr/lib/go-1.14/src/net/http/server.go:786 +0xf4
bufio.(*Reader).fill(0xc0001429c0)
        /usr/lib/go-1.14/src/bufio/bufio.go:100 +0x103
bufio.(*Reader).Peek(0xc0001429c0, 0x4, 0x1cc3d703f24, 0x11fe320, 0x0, 0x0, 0x11fe320)
        /usr/lib/go-1.14/src/bufio/bufio.go:138 +0x4f
net/http.(*conn).serve(0xc0000b6280, 0xd96c60, 0xc0006c1140)
        /usr/lib/go-1.14/src/net/http/server.go:1920 +0x9d7
created by net/http.(*Server).Serve
        /usr/lib/go-1.14/src/net/http/server.go:2933 +0x35c

goroutine 114 [IO wait]:
internal/poll.runtime_pollWait(0x7f41090bab00, 0x72, 0xffffffffffffffff)
        /usr/lib/go-1.14/src/runtime/netpoll.go:203 +0x55
internal/poll.(*pollDesc).wait(0xc000035718, 0x72, 0x1200, 0x12a6, 0xffffffffffffffff)
        /usr/lib/go-1.14/src/internal/poll/fd_poll_runtime.go:87 +0x45
internal/poll.(*pollDesc).waitRead(...)
        /usr/lib/go-1.14/src/internal/poll/fd_poll_runtime.go:92
internal/poll.(*FD).Read(0xc000035700, 0xc000219300, 0x12a6, 0x12a6, 0x0, 0x0, 0x0)
        /usr/lib/go-1.14/src/internal/poll/fd_unix.go:169 +0x19b
net.(*netFD).Read(0xc000035700, 0xc000219300, 0x12a6, 0x12a6, 0x203000, 0xc0002d67c0, 0xa)
        /usr/lib/go-1.14/src/net/fd_unix.go:202 +0x4f
net.(*conn).Read(0xc00011a0e8, 0xc000219300, 0x12a6, 0x12a6, 0x0, 0x0, 0x0)
        /usr/lib/go-1.14/src/net/net.go:184 +0x8e
crypto/tls.(*atLeastReader).Read(0xc000524c20, 0xc000219300, 0x12a6, 0x12a6, 0xc0000b6590, 0x186, 0xc00083f980)
        /usr/lib/go-1.14/src/crypto/tls/conn.go:760 +0x60
bytes.(*Buffer).ReadFrom(0xc0000de958, 0xd880e0, 0xc000524c20, 0x40bfc5, 0xa8b0c0, 0xb11a40)
        /usr/lib/go-1.14/src/bytes/buffer.go:204 +0xb1
crypto/tls.(*Conn).readFromUntil(0xc0000de700, 0xd88820, 0xc00011a0e8, 0x5, 0xc00011a0e8, 0xa49d40)
        /usr/lib/go-1.14/src/crypto/tls/conn.go:782 +0xec
crypto/tls.(*Conn).readRecordOrCCS(0xc0000de700, 0x0, 0x0, 0xb)
        /usr/lib/go-1.14/src/crypto/tls/conn.go:589 +0x115
crypto/tls.(*Conn).readRecord(...)
        /usr/lib/go-1.14/src/crypto/tls/conn.go:557
crypto/tls.(*Conn).Read(0xc0000de700, 0xc000240000, 0x1000, 0x1000, 0x0, 0x0, 0x0)
        /usr/lib/go-1.14/src/crypto/tls/conn.go:1233 +0x15b
bufio.(*Reader).fill(0xc000110840)
        /usr/lib/go-1.14/src/bufio/bufio.go:100 +0x103
bufio.(*Reader).Peek(0xc000110840, 0x2, 0x0, 0xc0003ae97e, 0xc0003ae97d, 0xc000688090, 0xc000300fc0)
        /usr/lib/go-1.14/src/bufio/bufio.go:138 +0x4f
github.com/gorilla/websocket.(*Conn).read(0xc0006de000, 0x2, 0xc000300900, 0x0, 0xc0002d6710, 0xc0002d6710, 0xc00083fd98)
        /home/jholdstock/code/gopath/pkg/mod/github.com/gorilla/websocket@v1.4.1/conn.go:370 +0x40
github.com/gorilla/websocket.(*Conn).advanceFrame(0xc0006de000, 0x0, 0x0, 0x40)
        /home/jholdstock/code/gopath/pkg/mod/github.com/gorilla/websocket@v1.4.1/conn.go:798 +0x5c
github.com/gorilla/websocket.(*Conn).NextReader(0xc0006de000, 0x45f6c0, 0xc0005c0b40, 0xc00083fea8, 0xc00083fea8, 0x40e8e8)
        /home/jholdstock/code/gopath/pkg/mod/github.com/gorilla/websocket@v1.4.1/conn.go:980 +0x8f
github.com/gorilla/websocket.(*Conn).ReadJSON(0xc0006de000, 0xa3a480, 0xc0001745f0, 0x2, 0xb446d0)
        /home/jholdstock/code/gopath/pkg/mod/github.com/gorilla/websocket@v1.4.1/json.go:50 +0x2f
github.com/jrick/wsrpc/v2.(*Client).in(0xc000880180, 0xd96d20, 0xc000689020)
        /home/jholdstock/code/gopath/pkg/mod/github.com/jrick/wsrpc/v2@v2.3.3/rpc.go:368 +0x20c
created by github.com/jrick/wsrpc/v2.Dial
        /home/jholdstock/code/gopath/pkg/mod/github.com/jrick/wsrpc/v2@v2.3.3/rpc.go:244 +0x38a

goroutine 115 [select]:
github.com/jrick/wsrpc/v2.(*Client).out(0xc000880180, 0xd96d20, 0xc000322180, 0xc0001740a0)
        /home/jholdstock/code/gopath/pkg/mod/github.com/jrick/wsrpc/v2@v2.3.3/rpc.go:313 +0x247
created by github.com/jrick/wsrpc/v2.Dial
        /home/jholdstock/code/gopath/pkg/mod/github.com/jrick/wsrpc/v2@v2.3.3/rpc.go:245 +0x3d3

goroutine 116 [IO wait, 1 minutes]:
internal/poll.runtime_pollWait(0x7f41090baf60, 0x72, 0xffffffffffffffff)
        /usr/lib/go-1.14/src/runtime/netpoll.go:203 +0x55
internal/poll.(*pollDesc).wait(0xc000034b98, 0x72, 0x700, 0x77a, 0xffffffffffffffff)
        /usr/lib/go-1.14/src/internal/poll/fd_poll_runtime.go:87 +0x45
internal/poll.(*pollDesc).waitRead(...)
        /usr/lib/go-1.14/src/internal/poll/fd_poll_runtime.go:92
internal/poll.(*FD).Read(0xc000034b80, 0xc000244800, 0x77a, 0x77a, 0x0, 0x0, 0x0)
        /usr/lib/go-1.14/src/internal/poll/fd_unix.go:169 +0x19b
net.(*netFD).Read(0xc000034b80, 0xc000244800, 0x77a, 0x77a, 0x203000, 0x6a0780, 0xc0000df2b8)
        /usr/lib/go-1.14/src/net/fd_unix.go:202 +0x4f
net.(*conn).Read(0xc00059a0e8, 0xc000244800, 0x77a, 0x77a, 0x0, 0x0, 0x0)
        /usr/lib/go-1.14/src/net/net.go:184 +0x8e
crypto/tls.(*atLeastReader).Read(0xc000844260, 0xc000244800, 0x77a, 0x77a, 0x13, 0x775, 0xc0005c9980)
        /usr/lib/go-1.14/src/crypto/tls/conn.go:760 +0x60
bytes.(*Buffer).ReadFrom(0xc0000df3d8, 0xd880e0, 0xc000844260, 0x40bfc5, 0xa8b0c0, 0xb11a40)
        /usr/lib/go-1.14/src/bytes/buffer.go:204 +0xb1
crypto/tls.(*Conn).readFromUntil(0xc0000df180, 0xd88820, 0xc00059a0e8, 0x5, 0xc00059a0e8, 0x2)
        /usr/lib/go-1.14/src/crypto/tls/conn.go:782 +0xec
crypto/tls.(*Conn).readRecordOrCCS(0xc0000df180, 0x0, 0x0, 0xe353b26971c)
        /usr/lib/go-1.14/src/crypto/tls/conn.go:589 +0x115
crypto/tls.(*Conn).readRecord(...)
        /usr/lib/go-1.14/src/crypto/tls/conn.go:557
crypto/tls.(*Conn).Read(0xc0000df180, 0xc0008dc000, 0x1000, 0x1000, 0x0, 0x0, 0x0)
        /usr/lib/go-1.14/src/crypto/tls/conn.go:1233 +0x15b
bufio.(*Reader).fill(0xc000596300)
        /usr/lib/go-1.14/src/bufio/bufio.go:100 +0x103
bufio.(*Reader).Peek(0xc000596300, 0x2, 0xc000880200, 0xc0003e4000, 0x11fe320, 0xb2ed60, 0xc000844240)
        /usr/lib/go-1.14/src/bufio/bufio.go:138 +0x4f
github.com/gorilla/websocket.(*Conn).read(0xc0003e4000, 0x2, 0x0, 0x0, 0x0, 0x0, 0x0)
        /home/jholdstock/code/gopath/pkg/mod/github.com/gorilla/websocket@v1.4.1/conn.go:370 +0x40
github.com/gorilla/websocket.(*Conn).advanceFrame(0xc0003e4000, 0xa, 0x0, 0x0)
        /home/jholdstock/code/gopath/pkg/mod/github.com/gorilla/websocket@v1.4.1/conn.go:798 +0x5c
github.com/gorilla/websocket.(*Conn).NextReader(0xc0003e4000, 0xc0005c9ea8, 0x406e5d, 0x60, 0xc0005c9ea8, 0x40e8e8)
        /home/jholdstock/code/gopath/pkg/mod/github.com/gorilla/websocket@v1.4.1/conn.go:980 +0x8f
github.com/gorilla/websocket.(*Conn).ReadJSON(0xc0003e4000, 0xa3a480, 0xc000098320, 0x2, 0xb446d0)
        /home/jholdstock/code/gopath/pkg/mod/github.com/gorilla/websocket@v1.4.1/json.go:50 +0x2f
github.com/jrick/wsrpc/v2.(*Client).in(0xc000880200, 0xd96d20, 0xc0001f9920)
        /home/jholdstock/code/gopath/pkg/mod/github.com/jrick/wsrpc/v2@v2.3.3/rpc.go:368 +0x20c
created by github.com/jrick/wsrpc/v2.Dial
        /home/jholdstock/code/gopath/pkg/mod/github.com/jrick/wsrpc/v2@v2.3.3/rpc.go:244 +0x38a

goroutine 117 [select, 1 minutes]:
github.com/jrick/wsrpc/v2.(*Client).out(0xc000880200, 0xd96d20, 0xc0001f9080, 0xc0000982d0)
        /home/jholdstock/code/gopath/pkg/mod/github.com/jrick/wsrpc/v2@v2.3.3/rpc.go:313 +0x247
created by github.com/jrick/wsrpc/v2.Dial
        /home/jholdstock/code/gopath/pkg/mod/github.com/jrick/wsrpc/v2@v2.3.3/rpc.go:245 +0x3d3

goroutine 149 [select, 1 minutes]:
github.com/jrick/wsrpc/v2.(*Client).out(0xc00068a700, 0xd96d20, 0xc00079bd70, 0xc000174fa0)
        /home/jholdstock/code/gopath/pkg/mod/github.com/jrick/wsrpc/v2@v2.3.3/rpc.go:313 +0x247
created by github.com/jrick/wsrpc/v2.Dial
        /home/jholdstock/code/gopath/pkg/mod/github.com/jrick/wsrpc/v2@v2.3.3/rpc.go:245 +0x3d3

goroutine 148 [IO wait, 1 minutes]:
internal/poll.runtime_pollWait(0x7f41090baa20, 0x72, 0xffffffffffffffff)
        /usr/lib/go-1.14/src/runtime/netpoll.go:203 +0x55
internal/poll.(*pollDesc).wait(0xc000880818, 0x72, 0x4700, 0x472a, 0xffffffffffffffff)
        /usr/lib/go-1.14/src/internal/poll/fd_poll_runtime.go:87 +0x45
internal/poll.(*pollDesc).waitRead(...)
        /usr/lib/go-1.14/src/internal/poll/fd_poll_runtime.go:92
internal/poll.(*FD).Read(0xc000880800, 0xc000380000, 0x472a, 0x472a, 0x0, 0x0, 0x0)
        /usr/lib/go-1.14/src/internal/poll/fd_unix.go:169 +0x19b
net.(*netFD).Read(0xc000880800, 0xc000380000, 0x472a, 0x472a, 0x203000, 0x6a0780, 0xc0001012b8)
        /usr/lib/go-1.14/src/net/fd_unix.go:202 +0x4f
net.(*conn).Read(0xc000518128, 0xc000380000, 0x472a, 0x472a, 0x0, 0x0, 0x0)
        /usr/lib/go-1.14/src/net/net.go:184 +0x8e
crypto/tls.(*atLeastReader).Read(0xc00014c0c0, 0xc000380000, 0x472a, 0x472a, 0x13, 0x4725, 0xc0005cf980)
        /usr/lib/go-1.14/src/crypto/tls/conn.go:760 +0x60
bytes.(*Buffer).ReadFrom(0xc0001013d8, 0xd880e0, 0xc00014c0c0, 0x40bfc5, 0xa8b0c0, 0xb11a40)
        /usr/lib/go-1.14/src/bytes/buffer.go:204 +0xb1
crypto/tls.(*Conn).readFromUntil(0xc000101180, 0xd88820, 0xc000518128, 0x5, 0xc000518128, 0x2)
        /usr/lib/go-1.14/src/crypto/tls/conn.go:782 +0xec
crypto/tls.(*Conn).readRecordOrCCS(0xc000101180, 0x0, 0x0, 0xe35afb4a327)
        /usr/lib/go-1.14/src/crypto/tls/conn.go:589 +0x115
crypto/tls.(*Conn).readRecord(...)
        /usr/lib/go-1.14/src/crypto/tls/conn.go:557
crypto/tls.(*Conn).Read(0xc000101180, 0xc0003b6000, 0x1000, 0x1000, 0x0, 0x0, 0x0)
        /usr/lib/go-1.14/src/crypto/tls/conn.go:1233 +0x15b
bufio.(*Reader).fill(0xc0007a67e0)
        /usr/lib/go-1.14/src/bufio/bufio.go:100 +0x103
bufio.(*Reader).Peek(0xc0007a67e0, 0x2, 0xc00068a700, 0xc0006de2c0, 0x11fe320, 0xb2ed60, 0xc00014c080)
        /usr/lib/go-1.14/src/bufio/bufio.go:138 +0x4f
github.com/gorilla/websocket.(*Conn).read(0xc0006de2c0, 0x2, 0x0, 0x0, 0x0, 0x0, 0x0)
        /home/jholdstock/code/gopath/pkg/mod/github.com/gorilla/websocket@v1.4.1/conn.go:370 +0x40
github.com/gorilla/websocket.(*Conn).advanceFrame(0xc0006de2c0, 0xa, 0x0, 0x0)
        /home/jholdstock/code/gopath/pkg/mod/github.com/gorilla/websocket@v1.4.1/conn.go:798 +0x5c
github.com/gorilla/websocket.(*Conn).NextReader(0xc0006de2c0, 0x45f6c0, 0xc0001428a0, 0xc0005cfea8, 0xc0005cfea8, 0x40e8e8)
        /home/jholdstock/code/gopath/pkg/mod/github.com/gorilla/websocket@v1.4.1/conn.go:980 +0x8f
github.com/gorilla/websocket.(*Conn).ReadJSON(0xc0006de2c0, 0xa3a480, 0xc000098370, 0x2, 0xb446d0)
        /home/jholdstock/code/gopath/pkg/mod/github.com/gorilla/websocket@v1.4.1/json.go:50 +0x2f
github.com/jrick/wsrpc/v2.(*Client).in(0xc00068a700, 0xd96d20, 0xc000323380)
        /home/jholdstock/code/gopath/pkg/mod/github.com/jrick/wsrpc/v2@v2.3.3/rpc.go:368 +0x20c
created by github.com/jrick/wsrpc/v2.Dial
        /home/jholdstock/code/gopath/pkg/mod/github.com/jrick/wsrpc/v2@v2.3.3/rpc.go:244 +0x38a

goroutine 575 [IO wait]:
internal/poll.runtime_pollWait(0x7f41090ba860, 0x72, 0xffffffffffffffff)
        /usr/lib/go-1.14/src/runtime/netpoll.go:203 +0x55
internal/poll.(*pollDesc).wait(0xc00068ab18, 0x72, 0x1000, 0x1000, 0xffffffffffffffff)
        /usr/lib/go-1.14/src/internal/poll/fd_poll_runtime.go:87 +0x45
internal/poll.(*pollDesc).waitRead(...)
        /usr/lib/go-1.14/src/internal/poll/fd_poll_runtime.go:92
internal/poll.(*FD).Read(0xc00068ab00, 0xc0003ba000, 0x1000, 0x1000, 0x0, 0x0, 0x0)
        /usr/lib/go-1.14/src/internal/poll/fd_unix.go:169 +0x19b
net.(*netFD).Read(0xc00068ab00, 0xc0003ba000, 0x1000, 0x1000, 0xc00023e140, 0xc0005c8800, 0x7524a3)
        /usr/lib/go-1.14/src/net/fd_unix.go:202 +0x4f
net.(*conn).Read(0xc0000100b8, 0xc0003ba000, 0x1000, 0x1000, 0x0, 0x0, 0x0)
        /usr/lib/go-1.14/src/net/net.go:184 +0x8e
net/http.(*connReader).Read(0xc000146840, 0xc0003ba000, 0x1000, 0x1000, 0x20300000000000, 0x7f410b445fff, 0xc0005c88e8)
        /usr/lib/go-1.14/src/net/http/server.go:786 +0xf4
bufio.(*Reader).fill(0xc0005c0ea0)
        /usr/lib/go-1.14/src/bufio/bufio.go:100 +0x103
bufio.(*Reader).ReadSlice(0xc0005c0ea0, 0x40a, 0x7f410b263e00, 0xc0005c89c0, 0x40e076, 0xc0004ff300, 0x100)
        /usr/lib/go-1.14/src/bufio/bufio.go:359 +0x3d
bufio.(*Reader).ReadLine(0xc0005c0ea0, 0xc0005c89c8, 0xc000066700, 0x7f4131d78560, 0x0, 0x3, 0x1)
        /usr/lib/go-1.14/src/bufio/bufio.go:388 +0x34
net/textproto.(*Reader).readLineSlice(0xc00079a000, 0xc0004ff300, 0x0, 0x12a05eb09, 0x800, 0x12a05eb09)
        /usr/lib/go-1.14/src/net/textproto/reader.go:58 +0x6c
net/textproto.(*Reader).ReadLine(...)
        /usr/lib/go-1.14/src/net/textproto/reader.go:39
net/http.readRequest(0xc0005c0ea0, 0xbfb2496cf7b7ab00, 0xc0004ff300, 0x0, 0x0)
        /usr/lib/go-1.14/src/net/http/request.go:1015 +0xa4
net/http.(*conn).readRequest(0xc0000b6640, 0xd96c60, 0xc00023e0c0, 0x0, 0x0, 0x0)
        /usr/lib/go-1.14/src/net/http/server.go:966 +0x191
net/http.(*conn).serve(0xc0000b6640, 0xd96c60, 0xc00023e0c0)
        /usr/lib/go-1.14/src/net/http/server.go:1822 +0x6d4
created by net/http.(*Server).Serve
        /usr/lib/go-1.14/src/net/http/server.go:2933 +0x35c

goroutine 576 [IO wait]:
internal/poll.runtime_pollWait(0x7f41090ba940, 0x72, 0xffffffffffffffff)
        /usr/lib/go-1.14/src/runtime/netpoll.go:203 +0x55
internal/poll.(*pollDesc).wait(0xc00068a898, 0x72, 0x0, 0x1, 0xffffffffffffffff)
        /usr/lib/go-1.14/src/internal/poll/fd_poll_runtime.go:87 +0x45
internal/poll.(*pollDesc).waitRead(...)
        /usr/lib/go-1.14/src/internal/poll/fd_poll_runtime.go:92
internal/poll.(*FD).Read(0xc00068a880, 0xc000112d61, 0x1, 0x1, 0x0, 0x0, 0x0)
        /usr/lib/go-1.14/src/internal/poll/fd_unix.go:169 +0x19b
net.(*netFD).Read(0xc00068a880, 0xc000112d61, 0x1, 0x1, 0x100010000, 0xc000116080, 0xc0005ae5a0)
        /usr/lib/go-1.14/src/net/fd_unix.go:202 +0x4f
net.(*conn).Read(0xc0000100b0, 0xc000112d61, 0x1, 0x1, 0x0, 0x0, 0x0)
        /usr/lib/go-1.14/src/net/net.go:184 +0x8e
net/http.(*connReader).backgroundRead(0xc000112d50)
        /usr/lib/go-1.14/src/net/http/server.go:678 +0x58
created by net/http.(*connReader).startBackgroundRead
        /usr/lib/go-1.14/src/net/http/server.go:674 +0xd0
```