### PR TITLE
Misc code cleanup

### DIFF
--- a/background/background.go
+++ b/background/background.go
@@ -30,9 +30,6 @@ const (
 	// requiredConfs is the number of confirmations required to consider a
 	// ticket purchase or a fee transaction to be final.
 	requiredConfs = 6
-	// errNoTxInfo is defined in dcrd/dcrjson. Copying here so we dont need to
-	// import the whole package.
-	errNoTxInfo = -5
 )
 
 // Notify is called every time a block notification is received from dcrd.
@@ -81,12 +78,12 @@ func blockConnected() {
 	for _, ticket := range unconfirmed {
 		tktTx, err := dcrdClient.GetRawTransaction(ticket.Hash)
 		if err != nil {
-			// errNoTxInfo here probably indicates a tx which was never mined
+			// ErrNoTxInfo here probably indicates a tx which was never mined
 			// and has been removed from the mempool. For example, a ticket
 			// purchase tx close to an sdiff change, or a ticket purchase tx
 			// which expired. Remove it from the db.
 			var e *wsrpc.Error
-			if errors.As(err, &e) && e.Code == errNoTxInfo {
+			if errors.As(err, &e) && e.Code == rpc.ErrNoTxInfo {
 				log.Infof("Removing unconfirmed ticket from db - no information available "+
 					"about transaction %s", err.Error())
 

--- a/rpc/dcrd.go
+++ b/rpc/dcrd.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/decred/dcrd/blockchain/stake/v3"
 	"github.com/decred/dcrd/chaincfg/v3"
 	dcrdtypes "github.com/decred/dcrd/rpc/jsonrpc/types/v2"
 	"github.com/decred/dcrd/wire"
@@ -138,38 +137,6 @@ func (c *DcrdRPC) SendRawTransaction(txHex string) error {
 		return err
 	}
 	return nil
-}
-
-func (c *DcrdRPC) GetTicketCommitmentAddress(ticketHash string, netParams *chaincfg.Params) (string, error) {
-	// Retrieve and parse the transaction.
-	resp, err := c.GetRawTransaction(ticketHash)
-	if err != nil {
-		return "", err
-	}
-	msgHex, err := hex.DecodeString(resp.Hex)
-	if err != nil {
-		return "", err
-	}
-	msgTx := wire.NewMsgTx()
-	if err = msgTx.FromBytes(msgHex); err != nil {
-		return "", err
-	}
-
-	// Ensure transaction is a valid ticket.
-	if !stake.IsSStx(msgTx) {
-		return "", errors.New("invalid transaction - not sstx")
-	}
-	if len(msgTx.TxOut) != 3 {
-		return "", fmt.Errorf("invalid transaction - expected 3 outputs, got %d", len(msgTx.TxOut))
-	}
-
-	// Get ticket commitment address.
-	addr, err := stake.AddrFromSStxPkScrCommitment(msgTx.TxOut[1].PkScript, netParams)
-	if err != nil {
-		return "", err
-	}
-
-	return addr.Address(), nil
 }
 
 func (c *DcrdRPC) NotifyBlocks() error {

--- a/rpc/dcrd.go
+++ b/rpc/dcrd.go
@@ -17,9 +17,13 @@ import (
 
 const (
 	requiredDcrdVersion = "6.1.1"
-	// errRPCDuplicateTx is defined in dcrd/dcrjson. Copying here so we dont
-	// need to import the whole package.
-	errRPCDuplicateTx = -40
+)
+
+// These error codes are defined in dcrd/dcrjson. They are copied here so we
+// dont need to import the whole package.
+const (
+	ErrRPCDuplicateTx = -40
+	ErrNoTxInfo       = -5
 )
 
 // DcrdRPC provides methods for calling dcrd JSON-RPCs without exposing the details
@@ -120,7 +124,7 @@ func (c *DcrdRPC) SendRawTransaction(txHex string) error {
 
 		// Exists in mempool.
 		var e *wsrpc.Error
-		if errors.As(err, &e) && e.Code == errRPCDuplicateTx {
+		if errors.As(err, &e) && e.Code == ErrRPCDuplicateTx {
 			return nil
 		}
 

--- a/webapi/errors.go
+++ b/webapi/errors.go
@@ -18,6 +18,7 @@ const (
 	errBadSignature
 	errInvalidPrivKey
 	errFeeNotReceived
+	errInvalidTicket
 )
 
 // httpStatus maps application error codes to HTTP status codes.
@@ -48,6 +49,8 @@ func (e apiError) httpStatus() int {
 	case errInvalidPrivKey:
 		return http.StatusBadRequest
 	case errFeeNotReceived:
+		return http.StatusBadRequest
+	case errInvalidTicket:
 		return http.StatusBadRequest
 	default:
 		return http.StatusInternalServerError
@@ -83,6 +86,8 @@ func (e apiError) defaultMessage() string {
 		return "invalid private key"
 	case errFeeNotReceived:
 		return "no fee tx received for ticket"
+	case errInvalidTicket:
+		return "not a valid ticket tx"
 	default:
 		return "unknown error"
 	}

--- a/webapi/getfeeaddress.go
+++ b/webapi/getfeeaddress.go
@@ -9,7 +9,6 @@ import (
 	"github.com/decred/vspd/database"
 	"github.com/decred/vspd/rpc"
 	"github.com/gin-gonic/gin"
-	"github.com/gin-gonic/gin/binding"
 )
 
 // addrMtx protects getNewFeeAddress.
@@ -62,7 +61,6 @@ func getCurrentFee(dcrdClient *rpc.DcrdRPC) (dcrutil.Amount, error) {
 func feeAddress(c *gin.Context) {
 
 	// Get values which have been added to context by middleware.
-	rawRequest := c.MustGet("RawRequest").([]byte)
 	ticket := c.MustGet("Ticket").(database.Ticket)
 	knownTicket := c.MustGet("KnownTicket").(bool)
 	commitmentAddress := c.MustGet("CommitmentAddress").(string)
@@ -74,7 +72,7 @@ func feeAddress(c *gin.Context) {
 	}
 
 	var feeAddressRequest FeeAddressRequest
-	if err := binding.JSON.BindBody(rawRequest, &feeAddressRequest); err != nil {
+	if err := c.ShouldBindJSON(&feeAddressRequest); err != nil {
 		log.Warnf("Bad feeaddress request from %s: %v", c.ClientIP(), err)
 		sendErrorWithMsg(err.Error(), errBadRequest, c)
 		return

--- a/webapi/payfee.go
+++ b/webapi/payfee.go
@@ -11,14 +11,12 @@ import (
 	"github.com/decred/vspd/database"
 	"github.com/decred/vspd/rpc"
 	"github.com/gin-gonic/gin"
-	"github.com/gin-gonic/gin/binding"
 )
 
 // payFee is the handler for "POST /payfee".
 func payFee(c *gin.Context) {
 
 	// Get values which have been added to context by middleware.
-	rawRequest := c.MustGet("RawRequest").([]byte)
 	ticket := c.MustGet("Ticket").(database.Ticket)
 	knownTicket := c.MustGet("KnownTicket").(bool)
 	dcrdClient := c.MustGet("DcrdClient").(*rpc.DcrdRPC)
@@ -35,7 +33,7 @@ func payFee(c *gin.Context) {
 	}
 
 	var payFeeRequest PayFeeRequest
-	if err := binding.JSON.BindBody(rawRequest, &payFeeRequest); err != nil {
+	if err := c.ShouldBindJSON(&payFeeRequest); err != nil {
 		log.Warnf("Bad payfee request from %s: %v", c.ClientIP(), err)
 		sendErrorWithMsg(err.Error(), errBadRequest, c)
 		return

--- a/webapi/payfee.go
+++ b/webapi/payfee.go
@@ -1,13 +1,11 @@
 package webapi
 
 import (
-	"encoding/hex"
 	"time"
 
 	"github.com/decred/dcrd/dcrec"
 	"github.com/decred/dcrd/dcrutil/v3"
 	"github.com/decred/dcrd/txscript/v3"
-	"github.com/decred/dcrd/wire"
 	"github.com/decred/vspd/database"
 	"github.com/decred/vspd/rpc"
 	"github.com/gin-gonic/gin"
@@ -95,16 +93,9 @@ func payFee(c *gin.Context) {
 	}
 
 	// Validate FeeTx.
-	feeTxBytes, err := hex.DecodeString(payFeeRequest.FeeTx)
+	feeTx, err := decodeTransaction(payFeeRequest.FeeTx)
 	if err != nil {
 		log.Warnf("Failed to decode tx: %v", err)
-		sendError(errInvalidFeeTx, c)
-		return
-	}
-
-	feeTx := wire.NewMsgTx()
-	if err = feeTx.FromBytes(feeTxBytes); err != nil {
-		log.Warnf("Failed to deserialize tx: %v", err)
 		sendError(errInvalidFeeTx, c)
 		return
 	}
@@ -150,15 +141,9 @@ findAddress:
 	}
 
 	// Decode ticket transaction to get its voting address.
-	ticketBytes, err := hex.DecodeString(rawTicket.Hex)
+	ticketTx, err := decodeTransaction(rawTicket.Hex)
 	if err != nil {
 		log.Warnf("Failed to decode tx: %v", err)
-		sendError(errInternalError, c)
-		return
-	}
-	ticketTx := wire.NewMsgTx()
-	if err = ticketTx.FromBytes(ticketBytes); err != nil {
-		log.Errorf("Failed to deserialize tx: %v", err)
 		sendError(errInternalError, c)
 		return
 	}

--- a/webapi/setvotechoices.go
+++ b/webapi/setvotechoices.go
@@ -6,14 +6,12 @@ import (
 	"github.com/decred/vspd/database"
 	"github.com/decred/vspd/rpc"
 	"github.com/gin-gonic/gin"
-	"github.com/gin-gonic/gin/binding"
 )
 
 // setVoteChoices is the handler for "POST /setvotechoices".
 func setVoteChoices(c *gin.Context) {
 
 	// Get values which have been added to context by middleware.
-	rawRequest := c.MustGet("RawRequest").([]byte)
 	ticket := c.MustGet("Ticket").(database.Ticket)
 	knownTicket := c.MustGet("KnownTicket").(bool)
 	walletClients := c.MustGet("WalletClients").([]*rpc.WalletRPC)
@@ -31,7 +29,7 @@ func setVoteChoices(c *gin.Context) {
 	}
 
 	var setVoteChoicesRequest SetVoteChoicesRequest
-	if err := binding.JSON.BindBody(rawRequest, &setVoteChoicesRequest); err != nil {
+	if err := c.ShouldBindJSON(&setVoteChoicesRequest); err != nil {
 		log.Warnf("Bad setvotechoices request from %s: %v", c.ClientIP(), err)
 		sendErrorWithMsg(err.Error(), errBadRequest, c)
 		return

--- a/webapi/ticketstatus.go
+++ b/webapi/ticketstatus.go
@@ -5,14 +5,12 @@ import (
 
 	"github.com/decred/vspd/database"
 	"github.com/gin-gonic/gin"
-	"github.com/gin-gonic/gin/binding"
 )
 
 // ticketStatus is the handler for "GET /ticketstatus".
 func ticketStatus(c *gin.Context) {
 
 	// Get values which have been added to context by middleware.
-	rawRequest := c.MustGet("RawRequest").([]byte)
 	ticket := c.MustGet("Ticket").(database.Ticket)
 	knownTicket := c.MustGet("KnownTicket").(bool)
 
@@ -23,7 +21,7 @@ func ticketStatus(c *gin.Context) {
 	}
 
 	var ticketStatusRequest TicketStatusRequest
-	if err := binding.JSON.BindBody(rawRequest, &ticketStatusRequest); err != nil {
+	if err := c.ShouldBindJSON(&ticketStatusRequest); err != nil {
 		log.Warnf("Bad ticketstatus request from %s: %v", c.ClientIP(), err)
 		sendErrorWithMsg(err.Error(), errBadRequest, c)
 		return


### PR DESCRIPTION
- Moving RPC errors to rpc package, rather than two different places
- Replace the request body reader with a new reader, which prevents the need to pass the raw body via context using hardcoded keys.