### PR TITLE
Don't write http body on db write error

### DIFF
--- a/webapi/admin.go
+++ b/webapi/admin.go
@@ -65,7 +65,9 @@ func downloadDatabaseBackup(c *gin.Context) {
 	err := db.BackupDB(c.Writer)
 	if err != nil {
 		log.Errorf("Error backing up database: %v", err)
-		c.String(http.StatusInternalServerError, "Error backing up database")
+		// Don't write any http body here because Content-Length has already
+		// been set in db.BackupDB. Status is enough to indicate an error.
+		c.Status(http.StatusInternalServerError)
 	}
 }
 


### PR DESCRIPTION
Client termination of http connection during a db backup was causing panics. This is because the Content-Length header was set to equal the db file size, but the code was attempting to write an error message with a different length.

Discovered by @degeri

```
2020-06-24 09:56:35.529 [ERR] API: Error backing up database: write tcp 127.0.0.1:8800->127.0.0.1:38180: write: connection reset by peer


2020/06/24 09:56:35 [Recovery] 2020/06/24 - 09:56:35 panic recovered:                                                                                 
http: wrote more than the declared Content-Length                          
/home/jholdstock/code/gopath/pkg/mod/github.com/gin-gonic/gin@v1.6.3/context.go:842 (0x9bf132)                                                        
        (*Context).Render: panic(err)                                      
/home/jholdstock/code/gopath/pkg/mod/github.com/gin-gonic/gin@v1.6.3/context.go:917 (0x9d75c2)                                                        
        (*Context).String: c.Render(code, render.String{Format: format, Data: values})                                                                
/home/jholdstock/code/jholdstock/vspd/webapi/admin.go:68 (0x9d7566)                                                                                   
        downloadDatabaseBackup: c.String(http.StatusInternalServerError, "Error backing up database")                                                 
/home/jholdstock/code/gopath/pkg/mod/github.com/gin-gonic/gin@v1.6.3/context.go:161 (0x9bb5ba)                                                        
        (*Context).Next: c.handlers[c.index](c)                            
/home/jholdstock/code/gopath/pkg/mod/github.com/gin-gonic/gin@v1.6.3/recovery.go:83 (0x9ce98f)                                                        
        RecoveryWithWriter.func1: c.Next()                                 
/home/jholdstock/code/gopath/pkg/mod/github.com/gin-gonic/gin@v1.6.3/context.go:161 (0x9bb5ba)                                                        
        (*Context).Next: c.handlers[c.index](c)                            
/home/jholdstock/code/gopath/pkg/mod/github.com/gin-gonic/gin@v1.6.3/gin.go:409 (0x9c5065)                                                            
        (*Engine).handleHTTPRequest: c.Next()                              
/home/jholdstock/code/gopath/pkg/mod/github.com/gin-gonic/gin@v1.6.3/gin.go:367 (0x9c477c)                                                            
        (*Engine).ServeHTTP: engine.handleHTTPRequest(c)                   
/usr/lib/go-1.14/src/net/http/server.go:2807 (0x75cbb2)                    
        serverHandler.ServeHTTP: handler.ServeHTTP(rw, req)                                                                                           
/usr/lib/go-1.14/src/net/http/server.go:1895 (0x75852b)                    
        (*conn).serve: serverHandler{c.server}.ServeHTTP(w, w.req)                                                                                    
/usr/lib/go-1.14/src/runtime/asm_amd64.s:1373 (0x4656b0)                   
        goexit: BYTE    $0x90   // NOP  
```
 