### PR TITLE
Load fonts.css last

### DIFF
--- a/webapi/templates/header.html
+++ b/webapi/templates/header.html
@@ -8,8 +8,9 @@
         <title>Decred VSP - {{ .VspStats.Designation }}</title>
 
         <link rel="stylesheet" href="/public/css/vendor/bootstrap.min.css" />
-        <link rel="stylesheet" href="/public/css/fonts.css" />
         <link rel="stylesheet" href="/public/css/vspd.css" />
+        <!-- fonts.css should be last to ensure dcr fonts take precedence. -->
+        <link rel="stylesheet" href="/public/css/fonts.css" />
 
         <!--  Custom favicon  -->
         <!-- Apple PWA -->


### PR DESCRIPTION
fonts.css should be loaded last to ensure dcr fonts take precedence over fonts in other css files