### PR TITLE
Add voting wallet status to admin page

### DIFF
--- a/background/background.go
+++ b/background/background.go
@@ -192,16 +192,9 @@ func blockConnected() {
 				continue
 			}
 			for _, walletClient := range walletClients {
-				err = walletClient.ImportPrivKey(ticket.VotingWIF)
+				err = walletClient.AddTicketForVoting(ticket.VotingWIF, rawTicket.BlockHash, rawTicket.Hex)
 				if err != nil {
-					log.Errorf("%s: dcrwallet.ImportPrivKey error (wallet=%s, ticketHash=%s): %v",
-						funcName, walletClient.String(), ticket.Hash, err)
-					continue
-				}
-
-				err = walletClient.AddTransaction(rawTicket.BlockHash, rawTicket.Hex)
-				if err != nil {
-					log.Errorf("%s: dcrwallet.AddTransaction error (wallet=%s, ticketHash=%s): %v",
+					log.Errorf("%s: dcrwallet.AddTicketForVoting error (wallet=%s, ticketHash=%s): %v",
 						funcName, walletClient.String(), ticket.Hash, err)
 					continue
 				}

--- a/background/background.go
+++ b/background/background.go
@@ -159,9 +159,9 @@ func blockConnected() {
 		log.Errorf("%s: Could not connect to any wallets", funcName)
 		return
 	}
-	if failedConnections > 0 {
+	if len(failedConnections) > 0 {
 		log.Errorf("%s: Failed to connect to %d wallet(s), proceeding with only %d",
-			funcName, failedConnections, len(walletClients))
+			funcName, len(failedConnections), len(walletClients))
 	}
 
 	for _, ticket := range unconfirmedFees {

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -76,6 +76,38 @@ dcrstakepool deployment.
 
 ## Monitoring
 
+### Logs
+
+Any event logged at the `[ERR]` level is worthy of immediate investigation.
+Examples include configuration or deployment issues, RPC failures and database
+errors.
+
+The `[WRN]` level is used to indicate events which are of interest, but do not
+necessarily require investigation (eg. bad requests from clients, recoverable
+errors).
+
+### Voting Wallets
+
+The current status of the voting wallets is displayed in a table on the `/admin`
+page, and the same information can be retrieved as a JSON object from
+`/admin/status` for automated monitoring.
+
+```json
+{
+  "wss://127.0.0.1:20111/ws":
+    {
+      "connected":true,
+      "infoerror":false,
+      "daemonconnected":true,
+      "voteversion":8,
+      "unlocked":true,
+      "voting":true,
+      "bestblockerror":false,
+      "bestblockheight":462345
+    }
+}
+```
+
 // TODO
 
 ## Backup

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -46,8 +46,8 @@ func setup(user, pass, addr string, cert []byte, n wsrpc.Notifier) *client {
 
 	var mu sync.Mutex
 	var c *wsrpc.Client
-
-	return &client{&mu, c, addr, tlsOpt, authOpt, n}
+	fullAddr := "wss://" + addr + "/ws"
+	return &client{&mu, c, fullAddr, tlsOpt, authOpt, n}
 }
 
 func (c *client) Close() {
@@ -85,8 +85,7 @@ func (c *client) dial(ctx context.Context) (Caller, bool, error) {
 	}
 
 	var err error
-	fullAddr := "wss://" + c.addr + "/ws"
-	c.client, err = wsrpc.Dial(ctx, fullAddr, c.tlsOpt, c.authOpt, wsrpc.WithNotifier(c.notifier))
+	c.client, err = wsrpc.Dial(ctx, c.addr, c.tlsOpt, c.authOpt, wsrpc.WithNotifier(c.notifier))
 	if err != nil {
 		return nil, false, err
 	}

--- a/rpc/dcrwallet.go
+++ b/rpc/dcrwallet.go
@@ -66,19 +66,19 @@ func (w *WalletConnect) Clients(ctx context.Context, netParams *chaincfg.Params)
 		var verMap map[string]dcrdtypes.VersionResult
 		err = c.Call(ctx, "version", &verMap)
 		if err != nil {
-			log.Errorf("version check on dcrwallet '%s' failed: %v", c.String(), err)
+			log.Errorf("dcrwallet.Version error (wallet=%s): %v", c.String(), err)
 			failedConnections = append(failedConnections, connect.addr)
 			continue
 		}
 		walletVersion, exists := verMap["dcrwalletjsonrpcapi"]
 		if !exists {
-			log.Errorf("version response on dcrwallet '%s' missing 'dcrwalletjsonrpcapi'",
+			log.Errorf("dcrwallet.Version response missing 'dcrwalletjsonrpcapi' (wallet=%s)",
 				c.String())
 			failedConnections = append(failedConnections, connect.addr)
 			continue
 		}
 		if walletVersion.VersionString != requiredWalletVersion {
-			log.Errorf("dcrwallet '%s' has wrong RPC version: got %s, expected %s",
+			log.Errorf("dcrwallet has wrong RPC version (wallet=%s): got %s, expected %s",
 				c.String(), walletVersion.VersionString, requiredWalletVersion)
 			failedConnections = append(failedConnections, connect.addr)
 			continue
@@ -88,12 +88,13 @@ func (w *WalletConnect) Clients(ctx context.Context, netParams *chaincfg.Params)
 		var netID wire.CurrencyNet
 		err = c.Call(ctx, "getcurrentnet", &netID)
 		if err != nil {
-			log.Errorf("getcurrentnet check on dcrwallet '%s' failed: %v", c.String(), err)
+			log.Errorf("dcrwallet.GetCurrentNet error (wallet=%s): %v", c.String(), err)
 			failedConnections = append(failedConnections, connect.addr)
 			continue
 		}
 		if netID != netParams.Net {
-			log.Errorf("dcrwallet '%s' running on %s, expected %s", c.String(), netID, netParams.Net)
+			log.Errorf("dcrwallet on wrong network (wallet=%s): running on %s, expected %s",
+				c.String(), netID, netParams.Net)
 			failedConnections = append(failedConnections, connect.addr)
 			continue
 		}
@@ -102,7 +103,7 @@ func (w *WalletConnect) Clients(ctx context.Context, netParams *chaincfg.Params)
 		walletRPC := &WalletRPC{c, ctx}
 		walletInfo, err := walletRPC.WalletInfo()
 		if err != nil {
-			log.Errorf("walletinfo check on dcrwallet '%s' failed: %v", c.String(), err)
+			log.Errorf("dcrwallet.WalletInfo error (wallet=%s): %v", c.String(), err)
 			failedConnections = append(failedConnections, connect.addr)
 			continue
 		}
@@ -110,12 +111,12 @@ func (w *WalletConnect) Clients(ctx context.Context, netParams *chaincfg.Params)
 		if !walletInfo.Voting {
 			// All wallet RPCs can still be used if voting is disabled, so just
 			// log an error here. Don't count this as a failed connection.
-			log.Errorf("wallet '%s' has voting disabled", c.String())
+			log.Errorf("wallet is not voting (wallet=%s)", c.String())
 		}
 		if !walletInfo.Unlocked {
 			// SetVoteChoice can still be used even if the wallet is locked, so
 			// just log an error here. Don't count this as a failed connection.
-			log.Errorf("wallet '%s' is not unlocked", c.String())
+			log.Errorf("wallet is not unlocked (wallet=%s)", c.String())
 		}
 
 		walletClients = append(walletClients, walletRPC)

--- a/rpc/dcrwallet.go
+++ b/rpc/dcrwallet.go
@@ -2,6 +2,7 @@ package rpc
 
 import (
 	"context"
+	"fmt"
 
 	wallettypes "decred.org/dcrwallet/rpc/jsonrpc/types"
 	"github.com/decred/dcrd/chaincfg/v3"
@@ -125,15 +126,21 @@ func (w *WalletConnect) Clients(ctx context.Context, netParams *chaincfg.Params)
 	return walletClients, failedConnections
 }
 
-func (c *WalletRPC) AddTransaction(blockHash, txHex string) error {
-	return c.Call(c.ctx, "addtransaction", nil, blockHash, txHex)
-}
-
-func (c *WalletRPC) ImportPrivKey(votingWIF string) error {
+func (c *WalletRPC) AddTicketForVoting(votingWIF, blockHash, txHex string) error {
 	label := "imported"
 	rescan := false
 	scanFrom := 0
-	return c.Call(c.ctx, "importprivkey", nil, votingWIF, label, rescan, scanFrom)
+	err := c.Call(c.ctx, "importprivkey", nil, votingWIF, label, rescan, scanFrom)
+	if err != nil {
+		return fmt.Errorf("importprivkey failed: %v", err)
+	}
+
+	err = c.Call(c.ctx, "addtransaction", nil, blockHash, txHex)
+	if err != nil {
+		return fmt.Errorf("addtransaction failed: %v", err)
+	}
+
+	return nil
 }
 
 func (c *WalletRPC) SetVoteChoice(agenda, choice, ticketHash string) error {

--- a/rpc/dcrwallet.go
+++ b/rpc/dcrwallet.go
@@ -155,3 +155,12 @@ func (c *WalletRPC) AddTicketForVoting(votingWIF, blockHash, txHex string) error
 func (c *WalletRPC) SetVoteChoice(agenda, choice, ticketHash string) error {
 	return c.Call(c.ctx, "setvotechoice", nil, agenda, choice, ticketHash)
 }
+
+func (c *WalletRPC) GetBestBlockHeight() (int64, error) {
+	var block dcrdtypes.GetBestBlockResult
+	err := c.Call(c.ctx, "getbestblock", &block)
+	if err != nil {
+		return 0, err
+	}
+	return block.Height, nil
+}

--- a/rpc/dcrwallet.go
+++ b/rpc/dcrwallet.go
@@ -113,10 +113,9 @@ func (w *WalletConnect) Clients(ctx context.Context, netParams *chaincfg.Params)
 			log.Errorf("wallet '%s' has voting disabled", c.String())
 		}
 		if !walletInfo.Unlocked {
-			// If wallet is locked, ImportPrivKey cannot be used.
+			// SetVoteChoice can still be used even if the wallet is locked, so
+			// just log an error here. Don't count this as a failed connection.
 			log.Errorf("wallet '%s' is not unlocked", c.String())
-			failedConnections++
-			continue
 		}
 
 		walletClients = append(walletClients, walletRPC)

--- a/webapi/admin.go
+++ b/webapi/admin.go
@@ -8,16 +8,18 @@ import (
 	"github.com/gorilla/sessions"
 )
 
-// WalletStatus describes the current status of a single voting wallet.
+// WalletStatus describes the current status of a single voting wallet. This is
+// used by the admin.html template, and also serialized to JSON for the
+// /admin/status endpoint.
 type WalletStatus struct {
-	Connected       bool
-	InfoError       bool
-	DaemonConnected bool
-	VoteVersion     uint32
-	Unlocked        bool
-	Voting          bool
-	BestBlockError  bool
-	BestBlockHeight int64
+	Connected       bool   `json:"connected"`
+	InfoError       bool   `json:"infoerror"`
+	DaemonConnected bool   `json:"daemonconnected"`
+	VoteVersion     uint32 `json:"voteversion"`
+	Unlocked        bool   `json:"unlocked"`
+	Voting          bool   `json:"voting"`
+	BestBlockError  bool   `json:"bestblockerror"`
+	BestBlockHeight int64  `json:"bestblockheight"`
 }
 
 func walletStatus(c *gin.Context) map[string]WalletStatus {
@@ -54,6 +56,12 @@ func walletStatus(c *gin.Context) map[string]WalletStatus {
 		walletStatus[v] = ws
 	}
 	return walletStatus
+}
+
+// statusJSON is the handler for "GET /admin/status". It returns a JSON object
+// describing the current status of voting wallets.
+func statusJSON(c *gin.Context) {
+	c.AbortWithStatusJSON(http.StatusOK, walletStatus(c))
 }
 
 // adminPage is the handler for "GET /admin".

--- a/webapi/middleware.go
+++ b/webapi/middleware.go
@@ -100,9 +100,9 @@ func withWalletClients(wallets rpc.WalletConnect) gin.HandlerFunc {
 			sendError(errInternalError, c)
 			return
 		}
-		if failedConnections > 0 {
+		if len(failedConnections) > 0 {
 			log.Errorf("Failed to connect to %d wallet(s), proceeding with only %d",
-				failedConnections, len(clients))
+				len(failedConnections), len(clients))
 		}
 		c.Set("WalletClients", clients)
 	}

--- a/webapi/middleware.go
+++ b/webapi/middleware.go
@@ -105,6 +105,7 @@ func withWalletClients(wallets rpc.WalletConnect) gin.HandlerFunc {
 				len(failedConnections), len(clients))
 		}
 		c.Set("WalletClients", clients)
+		c.Set("FailedWalletClients", failedConnections)
 	}
 }
 

--- a/webapi/public/css/vspd.css
+++ b/webapi/public/css/vspd.css
@@ -103,7 +103,8 @@ footer .code {
 .block__content th {
     font-weight: normal;
     padding-right: 15px;
-    text-align: right;
+    color: #495057;
+    background-color: #e9ecef;
 }
 
 .block__content table td {
@@ -114,4 +115,23 @@ footer .code {
 .block__content table th {
     vertical-align: top;
     white-space: nowrap;
+}
+
+td.status-good{
+    background-color: #C4ECCA;
+}
+td.status-bad{
+    background-color: #FEB8A5;
+}
+
+.ticket-table th {
+    text-align: right;
+}
+.ticket-table td {
+    text-align: left;
+}
+
+.status-table th,
+.status-table td {
+    text-align: center;
 }

--- a/webapi/templates/admin.html
+++ b/webapi/templates/admin.html
@@ -22,13 +22,69 @@
 </div>
 
 <div class="container">
+    <div class="row">
 
+        <div class="col-12 p-3">
+            <div class="block__content">
+                <h1>Voting Wallet Status</h1>
+
+                <table class="table status-table mb-0" width="100%">
+                    <tr>
+                        <th>URL</th>
+                        <th>Best Block Height</th>
+                        <th>Daemon Connected</th>
+                        <th>Unlocked</th>
+                        <th>Voting</th>
+                        <th>Vote Version</th>
+                    </tr>
+                    {{ range $host, $status := .WalletStatus }}
+                    <tr>
+                        <td>{{ $host }}</td>
+                        
+                        {{ if $status.Connected }}
+
+                            {{ if $status.BestBlockError }}
+                                <td class="status-bad">Error</td>
+                            {{ else }}
+                                <td>{{ $status.BestBlockHeight }}</td>
+                            {{ end }}
+
+                            {{ if $status.InfoError }}
+                                <td class="status-bad" colspan="4">Error</td>
+                            {{ else }}
+                                <td class="{{ if $status.DaemonConnected }}status-good{{else}}status-bad{{end}}"
+                                >{{ $status.DaemonConnected }}</td>
+                                
+                                
+                                <td class="{{ if $status.Unlocked }}status-good{{else}}status-bad{{end}}"
+                                >{{ $status.Unlocked }}</td>
+                                
+                                
+                                <td class="{{ if $status.Voting }}status-good{{else}}status-bad{{end}}"
+                                >{{ $status.Voting }}</td>
+                                
+                                <td>{{ $status.VoteVersion }}</td>
+                            {{ end }}
+
+                        {{else}}
+                            <td class="status-bad" colspan="4">Cannot connect to wallet</td>
+                        {{end}}
+                    </tr>
+                    {{end}}
+                </table>
+
+            </div>
+        </div>
+
+    </div>
+</div>
+
+<div class="container">
     <div class="row">
 
         <div class="col-12 p-3">
             <div class="block__content">
                 <h1>Ticket Search</h1>
-    
 
                 <form class="my-2" action="/admin/ticket" method="post">
                     <input type="text" name="hash" size="64" minlength="64" maxlength="64" required placeholder="Ticket hash" autocomplete="off">
@@ -38,7 +94,7 @@
                 {{ with .SearchResult }}
                     {{ if .Found }}
                         {{ with .Ticket }}
-                            <table class="table mt-4 mb-0">
+                            <table class="table ticket-table mt-4 mb-0">
                                 <tr>
                                     <th>Hash</th>
                                     <td>{{ .Hash }}</td>
@@ -104,7 +160,6 @@
         </div>
 
     </div>
-
 </div>
 
 {{ template "footer" . }}

--- a/webapi/webapi.go
+++ b/webapi/webapi.go
@@ -208,6 +208,7 @@ func router(debugMode bool, cookieSecret []byte, dcrd rpc.DcrdConnect, wallets r
 		withWalletClients(wallets), withSession(cookieStore), requireAdmin(),
 	)
 	admin.GET("", adminPage)
+	admin.GET("/status", statusJSON)
 	admin.POST("/ticket", ticketSearch)
 	admin.GET("/backup", downloadDatabaseBackup)
 	admin.POST("/logout", adminLogout)

--- a/webapi/webapi.go
+++ b/webapi/webapi.go
@@ -205,7 +205,7 @@ func router(debugMode bool, cookieSecret []byte, dcrd rpc.DcrdConnect, wallets r
 	login.POST("", adminLogin)
 
 	admin := router.Group("/admin").Use(
-		withSession(cookieStore), requireAdmin(),
+		withWalletClients(wallets), withSession(cookieStore), requireAdmin(),
 	)
 	admin.GET("", adminPage)
 	admin.POST("/ticket", ticketSearch)


### PR DESCRIPTION
Quite a few changes here but they are broken into self contained commits to aid reviewing.

Adds a table to the admin page which details the status of each voting wallet. This is similar to how dcrstakepool displays its back-end statuses.

Started to add some monitoring docs for #102 