### PR TITLE
base64 encoding for pubkey on homepage

### DIFF
--- a/webapi/homepage.go
+++ b/webapi/homepage.go
@@ -1,6 +1,7 @@
 package webapi
 
 import (
+	"encoding/base64"
 	"net/http"
 	"sync"
 	"time"
@@ -11,7 +12,7 @@ import (
 )
 
 type vspStats struct {
-	PubKey              []byte
+	PubKey              string
 	TotalTickets        int
 	FeeConfirmedTickets int
 	VSPFee              float64
@@ -43,7 +44,7 @@ func updateVSPStats(db *database.VspDatabase, cfg Config) error {
 	defer statsMtx.Unlock()
 
 	stats = &vspStats{
-		PubKey:              signPubKey,
+		PubKey:              base64.StdEncoding.EncodeToString(signPubKey),
 		TotalTickets:        total,
 		FeeConfirmedTickets: feeConfirmed,
 		VSPFee:              cfg.VSPFee,

--- a/webapi/templates/footer.html
+++ b/webapi/templates/footer.html
@@ -9,7 +9,7 @@
               <br />
               <strong>Support:</strong>&nbsp;<a href="mailto:{{ .VspStats.SupportEmail }}" rel="noopener noreferrer">{{ .VspStats.SupportEmail }}</a>
               <br />
-              <strong>VSP&nbsp;public&nbsp;key:</strong>&nbsp;<span class="code">{{ printf "%x" .VspStats.PubKey }}</span>
+              <strong>VSP&nbsp;public&nbsp;key:</strong>&nbsp;<span class="code">{{ .VspStats.PubKey }}</span>
             </p>
         </div>
 


### PR DESCRIPTION
To match encoding returned by the `/api/vspinfo` endpoint