### PR TITLE
Remove timestamp from ticket status request

### DIFF
--- a/webapi/types.go
+++ b/webapi/types.go
@@ -48,7 +48,6 @@ type setVoteChoicesResponse struct {
 }
 
 type TicketStatusRequest struct {
-	Timestamp  int64  `json:"timestamp" binding:"required"`
 	TicketHash string `json:"tickethash" binding:"required"`
 }
 


### PR DESCRIPTION
This enables clients to cache and re-use their signed requests, preventing the need to unlock wallet every time.