### PR TITLE
Configure RPC auth per wallet host.

### DIFF
--- a/harness.sh
+++ b/harness.sh
@@ -74,7 +74,20 @@ sleep 1 # Give dcrd time to start
 
 for ((i = 1; i <= $NUMBER_OF_WALLETS; i++)); do
     WALLET_RPC_LISTEN="127.0.0.1:2011${i}"
-    ALL_WALLETS="${ALL_WALLETS}"$'\n'wallethost="${WALLET_RPC_LISTEN}"
+
+    # Concatenate all wallet details for vspd config file.
+    if [ $i == 1 ]; then
+        ALL_WALLET_HOST="${WALLET_RPC_LISTEN}"
+        ALL_WALLET_USER="${RPC_USER}"
+        ALL_WALLET_PASS="${RPC_PASS}"
+        ALL_WALLET_CERT="${WALLET_RPC_CERT}"
+    else
+        ALL_WALLET_HOST="${ALL_WALLET_HOST},${WALLET_RPC_LISTEN}"
+        ALL_WALLET_USER="${ALL_WALLET_USER},${RPC_USER}"
+        ALL_WALLET_PASS="${ALL_WALLET_PASS},${RPC_PASS}"
+        ALL_WALLET_CERT="${ALL_WALLET_CERT},${WALLET_RPC_CERT}"
+    fi
+
 
 echo ""
 echo "Writing config for dcrwallet-${i}"
@@ -115,10 +128,10 @@ cat > "${HARNESS_ROOT}/vspd/vspd.conf" <<EOF
 dcrduser = ${RPC_USER}
 dcrdpass = ${RPC_PASS}
 dcrdcert = ${DCRD_RPC_CERT}
-${ALL_WALLETS}
-walletuser = ${RPC_USER}
-walletpass = ${RPC_PASS}
-walletcert = ${WALLET_RPC_CERT}
+wallethost = ${ALL_WALLET_HOST}
+walletuser = ${ALL_WALLET_USER}
+walletpass = ${ALL_WALLET_PASS}
+walletcert = ${ALL_WALLET_CERT}
 loglevel = debug
 network = testnet
 webserverdebug = false

--- a/rpc/dcrwallet.go
+++ b/rpc/dcrwallet.go
@@ -23,11 +23,11 @@ type WalletRPC struct {
 
 type WalletConnect []*client
 
-func SetupWallet(user, pass string, addrs []string, cert []byte) WalletConnect {
+func SetupWallet(user, pass, addrs []string, cert [][]byte) WalletConnect {
 	walletConnect := make(WalletConnect, len(addrs))
 
 	for i := 0; i < len(addrs); i++ {
-		walletConnect[i] = setup(user, pass, addrs[i], cert, nil)
+		walletConnect[i] = setup(user[i], pass[i], addrs[i], cert[i], nil)
 	}
 
 	return walletConnect

--- a/vspd.go
+++ b/vspd.go
@@ -70,7 +70,7 @@ func run(ctx context.Context) error {
 	defer dcrd.Close()
 
 	// Create RPC client for remote dcrwallet instance (used for voting).
-	wallets := rpc.SetupWallet(cfg.WalletUser, cfg.WalletPass, cfg.WalletHosts, cfg.walletCert)
+	wallets := rpc.SetupWallet(cfg.walletUsers, cfg.walletPasswords, cfg.walletHosts, cfg.walletCerts)
 	defer wallets.Close()
 
 	// Create and start webapi server.


### PR DESCRIPTION
This PR enables RPC details to be configured for each wallet host, rather than using the same details for every host. (Closes #162)

Note that this includes a change to config syntax, the list of wallet hosts is now comma separated rather than being specified multiple times. For example...

**Before**
```
wallethost = 127.0.0.1:20111
wallethost = 127.0.0.1:20112
walletuser = user
walletpass = pass
walletcert = rpc.cert
```

**After**
```
wallethost = 127.0.0.1:20111,127.0.0.1:20112
walletuser = user,user
walletpass = pass,pass
walletcert = rpc.cert,rpc.cert
```
