### PR TITLE
Only load .html files in template dir

### DIFF
--- a/webapi/webapi.go
+++ b/webapi/webapi.go
@@ -167,7 +167,7 @@ func router(debugMode bool, cookieSecret []byte, dcrd rpc.DcrdConnect, wallets r
 	}
 
 	router := gin.New()
-	router.LoadHTMLGlob("webapi/templates/*")
+	router.LoadHTMLGlob("webapi/templates/*.html")
 
 	// Recovery middleware handles any go panics generated while processing web
 	// requests. Ensures a 500 response is sent to the client rather than


### PR DESCRIPTION
To fix an issue seen by @isuldor

vspd does not need to parse non-html files in the template dir (eg. temporary/hidden files created by text editors)