### PR TITLE
webapi: base64 encode server signature

### DIFF
--- a/webapi/webapi.go
+++ b/webapi/webapi.go
@@ -7,7 +7,7 @@ package webapi
 import (
 	"context"
 	"crypto/ed25519"
-	"encoding/hex"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"net"
@@ -236,7 +236,7 @@ func sendJSONResponse(resp interface{}, c *gin.Context) {
 	}
 
 	sig := ed25519.Sign(signPrivKey, dec)
-	c.Writer.Header().Set("VSP-Server-Signature", hex.EncodeToString(sig))
+	c.Writer.Header().Set("VSP-Server-Signature", base64.StdEncoding.EncodeToString(sig))
 
 	c.AbortWithStatusJSON(http.StatusOK, resp)
 }
@@ -264,7 +264,7 @@ func sendErrorWithMsg(msg string, e apiError, c *gin.Context) {
 		log.Warnf("Sending error response without signature: %v", err)
 	} else {
 		sig := ed25519.Sign(signPrivKey, dec)
-		c.Writer.Header().Set("VSP-Server-Signature", hex.EncodeToString(sig))
+		c.Writer.Header().Set("VSP-Server-Signature", base64.StdEncoding.EncodeToString(sig))
 	}
 
 	c.AbortWithStatusJSON(status, resp)


### PR DESCRIPTION
vspd was accepting `VSP-Client-Signature` base64 encoded, but then returning `VSP-Server-Signature` hex encoded.

For the sake of maintaining a consistent API, this PR changes the server signature to also use base64 encoding.