### PR TITLE
Tidy up shutdown logic

### DIFF
--- a/background/background.go
+++ b/background/background.go
@@ -279,7 +279,7 @@ func (n *NotificationHandler) Close() error {
 func connectNotifier(shutdownCtx context.Context, dcrdWithNotifs rpc.DcrdConnect) error {
 	notifierClosed = make(chan struct{})
 
-	dcrdClient, err := dcrdWithNotifs.Client(context.Background(), netParams)
+	dcrdClient, err := dcrdWithNotifs.Client(shutdownCtx, netParams)
 	if err != nil {
 		return err
 	}
@@ -295,6 +295,9 @@ func connectNotifier(shutdownCtx context.Context, dcrdWithNotifs rpc.DcrdConnect
 	// notifier is closed.
 	select {
 	case <-shutdownCtx.Done():
+		// A shutdown signal has been received - close the client with the
+		// notification handler to prevent further notifications from being
+		// received.
 		dcrdWithNotifs.Close()
 		return nil
 	case <-notifierClosed:

--- a/background/background.go
+++ b/background/background.go
@@ -19,13 +19,11 @@ import (
 )
 
 var (
-	ctx            context.Context
 	db             *database.VspDatabase
 	dcrdRPC        rpc.DcrdConnect
 	walletRPC      rpc.WalletConnect
 	netParams      *chaincfg.Params
 	notifierClosed chan struct{}
-	shutdownWg     *sync.WaitGroup
 )
 
 type NotificationHandler struct{}
@@ -66,8 +64,7 @@ func blockConnected() {
 
 	funcName := "blockConnected"
 
-	shutdownWg.Add(1)
-	defer shutdownWg.Done()
+	ctx := context.Background()
 
 	dcrdClient, err := dcrdRPC.Client(ctx, netParams)
 	if err != nil {
@@ -279,10 +276,10 @@ func (n *NotificationHandler) Close() error {
 	return nil
 }
 
-func connectNotifier(dcrdWithNotifs rpc.DcrdConnect) error {
+func connectNotifier(shutdownCtx context.Context, dcrdWithNotifs rpc.DcrdConnect) error {
 	notifierClosed = make(chan struct{})
 
-	dcrdClient, err := dcrdWithNotifs.Client(ctx, netParams)
+	dcrdClient, err := dcrdWithNotifs.Client(context.Background(), netParams)
 	if err != nil {
 		return err
 	}
@@ -297,7 +294,7 @@ func connectNotifier(dcrdWithNotifs rpc.DcrdConnect) error {
 	// Wait until context is done (vspd is shutting down), or until the
 	// notifier is closed.
 	select {
-	case <-ctx.Done():
+	case <-shutdownCtx.Done():
 		dcrdWithNotifs.Close()
 		return nil
 	case <-notifierClosed:
@@ -306,15 +303,13 @@ func connectNotifier(dcrdWithNotifs rpc.DcrdConnect) error {
 	}
 }
 
-func Start(c context.Context, wg *sync.WaitGroup, vdb *database.VspDatabase, drpc rpc.DcrdConnect,
+func Start(shutdownCtx context.Context, wg *sync.WaitGroup, vdb *database.VspDatabase, drpc rpc.DcrdConnect,
 	dcrdWithNotif rpc.DcrdConnect, wrpc rpc.WalletConnect, p *chaincfg.Params) {
 
-	ctx = c
 	db = vdb
 	dcrdRPC = drpc
 	walletRPC = wrpc
 	netParams = p
-	shutdownWg = wg
 
 	// Run the block connected handler now to catch up with any blocks mined
 	// while vspd was shut down.
@@ -325,24 +320,30 @@ func Start(c context.Context, wg *sync.WaitGroup, vdb *database.VspDatabase, drp
 	checkWalletConsistency()
 
 	// Run voting wallet consistency check periodically.
+	wg.Add(1)
 	go func() {
 		ticker := time.NewTicker(consistencyInterval)
+	consistencyLoop:
 		for {
 			select {
-			case <-ctx.Done():
+			case <-shutdownCtx.Done():
 				ticker.Stop()
-				return
+				break consistencyLoop
 			case <-ticker.C:
 				checkWalletConsistency()
 			}
 		}
+		log.Debugf("Consistency checker stopped")
+		wg.Done()
 	}()
 
 	// Loop forever attempting to create a connection to the dcrd server for
 	// notifications.
+	wg.Add(1)
 	go func() {
+	notifierLoop:
 		for {
-			err := connectNotifier(dcrdWithNotif)
+			err := connectNotifier(shutdownCtx, dcrdWithNotif)
 			if err != nil {
 				log.Errorf("dcrd connect error: %v", err)
 			}
@@ -350,12 +351,14 @@ func Start(c context.Context, wg *sync.WaitGroup, vdb *database.VspDatabase, drp
 			// If context is done (vspd is shutting down), return,
 			// otherwise wait 15 seconds and try to reconnect.
 			select {
-			case <-ctx.Done():
-				return
+			case <-shutdownCtx.Done():
+				break notifierLoop
 			case <-time.After(15 * time.Second):
 			}
 
 		}
+		log.Debugf("Notification connector stopped")
+		wg.Done()
 	}()
 }
 
@@ -367,6 +370,8 @@ func checkWalletConsistency() {
 	funcName := "checkWalletConsistency"
 
 	log.Info("Checking voting wallet consistency")
+
+	ctx := context.Background()
 
 	dcrdClient, err := dcrdRPC.Client(ctx, netParams)
 	if err != nil {

--- a/background/background.go
+++ b/background/background.go
@@ -298,6 +298,7 @@ func connectNotifier(dcrdWithNotifs rpc.DcrdConnect) error {
 	// notifier is closed.
 	select {
 	case <-ctx.Done():
+		dcrdWithNotifs.Close()
 		return nil
 	case <-notifierClosed:
 		log.Warnf("dcrd notifier closed")


### PR DESCRIPTION
Removing the use of a global context and global WaitGroup in `background.go`. Should close #173 

Background processes triggered by timers were previously adding 1 to the shutdown WaitGroup each time they were triggered, and subtracting 1 each time they completed. This resulted in #173, where the WaitGroup was incremented incorrectly. Now - the WaitGroup is incremented once when the timer is started, and once when it has stopped. 

This change - as well as using a background context for these background tasks - also helps shutdown to be more robust. Now the background processes will terminate before shutdown proceeds, whereas previously they could be interrupted.

Another added benefit is that the global copies of the WaitGroup and the shutdown context in `background.go` are removed by this PR.