### PR TITLE
Make funcNames constant.

### DIFF
--- a/background/background.go
+++ b/background/background.go
@@ -64,7 +64,7 @@ func (n *NotificationHandler) Notify(method string, params json.RawMessage) erro
 // blockconnected notification is received from dcrd.
 func blockConnected() {
 
-	funcName := "blockConnected"
+	const funcName = "blockConnected"
 
 	shutdownWg.Add(1)
 	defer shutdownWg.Done()
@@ -363,7 +363,7 @@ func Start(c context.Context, wg *sync.WaitGroup, vdb *database.VspDatabase, drp
 // choices.
 func checkWalletConsistency() {
 
-	funcName := "checkWalletConsistency"
+	const funcName = "checkWalletConsistency"
 
 	log.Info("Checking voting wallet consistency")
 

--- a/webapi/getfeeaddress.go
+++ b/webapi/getfeeaddress.go
@@ -64,7 +64,7 @@ func getCurrentFee(dcrdClient *rpc.DcrdRPC) (dcrutil.Amount, error) {
 // feeAddress is the handler for "POST /api/v3/feeaddress".
 func feeAddress(c *gin.Context) {
 
-	funcName := "feeAddress"
+	const funcName = "feeAddress"
 
 	// Get values which have been added to context by middleware.
 	ticket := c.MustGet("Ticket").(database.Ticket)

--- a/webapi/middleware.go
+++ b/webapi/middleware.go
@@ -116,7 +116,7 @@ func withWalletClients(wallets rpc.WalletConnect) gin.HandlerFunc {
 // If no info can be found, the ticket hex will be broadcast.
 func broadcastTicket() gin.HandlerFunc {
 	return func(c *gin.Context) {
-		funcName := "broadcastTicket"
+		const funcName = "broadcastTicket"
 
 		// Read request bytes and then replace the request reader for
 		// downstream handlers to use.
@@ -201,7 +201,7 @@ func broadcastTicket() gin.HandlerFunc {
 // use.
 func vspAuth() gin.HandlerFunc {
 	return func(c *gin.Context) {
-		funcName := "vspAuth"
+		const funcName = "vspAuth"
 
 		// Read request bytes and then replace the request reader for
 		// downstream handlers to use.

--- a/webapi/payfee.go
+++ b/webapi/payfee.go
@@ -18,7 +18,7 @@ import (
 
 // payFee is the handler for "POST /api/v3/payfee".
 func payFee(c *gin.Context) {
-	funcName := "payFee"
+	const funcName = "payFee"
 
 	// Get values which have been added to context by middleware.
 	ticket := c.MustGet("Ticket").(database.Ticket)

--- a/webapi/setvotechoices.go
+++ b/webapi/setvotechoices.go
@@ -14,7 +14,7 @@ import (
 
 // setVoteChoices is the handler for "POST /api/v3/setvotechoices".
 func setVoteChoices(c *gin.Context) {
-	funcName := "setVoteChoices"
+	const funcName = "setVoteChoices"
 
 	// Get values which have been added to context by middleware.
 	ticket := c.MustGet("Ticket").(database.Ticket)

--- a/webapi/ticketstatus.go
+++ b/webapi/ticketstatus.go
@@ -13,7 +13,7 @@ import (
 
 // ticketStatus is the handler for "POST /api/v3/ticketstatus".
 func ticketStatus(c *gin.Context) {
-	funcName := "ticketStatus"
+	const funcName = "ticketStatus"
 
 	// Get values which have been added to context by middleware.
 	ticket := c.MustGet("Ticket").(database.Ticket)


### PR DESCRIPTION
Aside from just being a sensible thing to do, this also prevents a local stack allocation.