### PR TITLE
rpc: optimize TicketInfo

### DIFF
--- a/background/background.go
+++ b/background/background.go
@@ -106,6 +106,7 @@ func blockConnected() {
 		}
 
 		if tktTx.Confirmations >= requiredConfs {
+			ticket.PurchaseHeight = tktTx.BlockHeight
 			ticket.Confirmed = true
 			err = db.UpdateTicket(ticket)
 			if err != nil {

--- a/database/ticket.go
+++ b/database/ticket.go
@@ -43,6 +43,7 @@ const (
 // deliberately kept short because they are duplicated many times in the db.
 type Ticket struct {
 	Hash              string `json:"hsh"`
+	PurchaseHeight    int64  `json:"phgt"`
 	CommitmentAddress string `json:"cmtaddr"`
 	FeeAddressIndex   uint32 `json:"faddridx"`
 	FeeAddress        string `json:"faddr"`

--- a/rpc/dcrwallet.go
+++ b/rpc/dcrwallet.go
@@ -181,15 +181,15 @@ func (c *WalletRPC) SetVoteChoice(agenda, choice, ticketHash string) error {
 	return c.Call(c.ctx, "setvotechoice", nil, agenda, choice, ticketHash)
 }
 
-// GetBestBlockHeight uses getbestblock RPC to query the height of the best
+// GetBestBlockHeight uses getblockcount RPC to query the height of the best
 // block known by the dcrwallet instance.
 func (c *WalletRPC) GetBestBlockHeight() (int64, error) {
-	var block dcrdtypes.GetBestBlockResult
-	err := c.Call(c.ctx, "getbestblock", &block)
+	var height int64
+	err := c.Call(c.ctx, "getblockcount", &height)
 	if err != nil {
 		return 0, err
 	}
-	return block.Height, nil
+	return height, nil
 }
 
 // TicketInfo uses ticketinfo RPC to retrieve a detailed list of all tickets

--- a/rpc/dcrwallet.go
+++ b/rpc/dcrwallet.go
@@ -194,9 +194,9 @@ func (c *WalletRPC) GetBestBlockHeight() (int64, error) {
 
 // TicketInfo uses ticketinfo RPC to retrieve a detailed list of all tickets
 // known by this dcrwallet instance.
-func (c *WalletRPC) TicketInfo() (map[string]*wallettypes.TicketInfoResult, error) {
+func (c *WalletRPC) TicketInfo(startHeight int64) (map[string]*wallettypes.TicketInfoResult, error) {
 	var result []*wallettypes.TicketInfoResult
-	err := c.Call(c.ctx, "ticketinfo", &result)
+	err := c.Call(c.ctx, "ticketinfo", &result, startHeight)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This changes TicketInfo to only scan from the block height
required to reconcile.

Also, update GetBestBlockHeight to just use getblockcount