### PR TITLE
HTTP 428 when fee tx references unknown outputs.

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -4,7 +4,7 @@
 
 - Success responses use HTTP status 200 and a JSON encoded body.
 
-- Error responses use HTTP status 500 to indicate a server error or 400 to
+- Error responses use HTTP status 500 to indicate a server error or 4XX to
   indiciate a client error, and will include a JSON body describing the error.
   For example:
 

--- a/webapi/errors.go
+++ b/webapi/errors.go
@@ -25,6 +25,7 @@ const (
 	errInvalidTicket
 	errCannotBroadcastTicket
 	errCannotBroadcastFee
+	errCannotBroadcastFeeUnknownOutputs
 )
 
 // httpStatus maps application error codes to HTTP status codes.
@@ -62,6 +63,8 @@ func (e apiError) httpStatus() int {
 		return http.StatusInternalServerError
 	case errCannotBroadcastFee:
 		return http.StatusInternalServerError
+	case errCannotBroadcastFeeUnknownOutputs:
+		return http.StatusPreconditionRequired
 	default:
 		return http.StatusInternalServerError
 	}
@@ -102,6 +105,8 @@ func (e apiError) defaultMessage() string {
 		return "ticket transaction could not be broadcast"
 	case errCannotBroadcastFee:
 		return "fee transaction could not be broadcast"
+	case errCannotBroadcastFeeUnknownOutputs:
+		return "fee transaction could not be broadcast due to unknown outputs"
 	default:
 		return "unknown error"
 	}

--- a/webapi/payfee.go
+++ b/webapi/payfee.go
@@ -5,6 +5,7 @@
 package webapi
 
 import (
+	"strings"
 	"time"
 
 	"github.com/decred/dcrd/blockchain/v3"
@@ -246,7 +247,12 @@ findAddress:
 					funcName, ticket.Hash, err)
 			}
 
-			sendErrorWithMsg("could not broadcast fee transaction", errCannotBroadcastFee, c)
+			if strings.Contains(err.Error(),
+				"references outputs of unknown or fully-spent transaction") {
+				sendError(errCannotBroadcastFeeUnknownOutputs, c)
+			} else {
+				sendError(errCannotBroadcastFee, c)
+			}
 			return
 		}
 


### PR DESCRIPTION
JSON body will be `{"code": 16, "message":"fee transaction could not be broadcast due to unknown outputs"}`