### PR TITLE
Use actual request in response, dont reserialize.

### DIFF
--- a/webapi/getfeeaddress.go
+++ b/webapi/getfeeaddress.go
@@ -147,7 +147,7 @@ func feeAddress(c *gin.Context) {
 		}
 		sendJSONResponse(feeAddressResponse{
 			Timestamp:  now.Unix(),
-			Request:    request,
+			Request:    reqBytes,
 			FeeAddress: ticket.FeeAddress,
 			FeeAmount:  ticket.FeeAmount,
 			Expiration: ticket.FeeExpiration,
@@ -200,7 +200,7 @@ func feeAddress(c *gin.Context) {
 
 	sendJSONResponse(feeAddressResponse{
 		Timestamp:  now.Unix(),
-		Request:    request,
+		Request:    reqBytes,
 		FeeAddress: newAddress,
 		FeeAmount:  int64(fee),
 		Expiration: expire,

--- a/webapi/payfee.go
+++ b/webapi/payfee.go
@@ -276,7 +276,7 @@ findAddress:
 	// Send success response to client.
 	resp, respSig := sendJSONResponse(payFeeResponse{
 		Timestamp: time.Now().Unix(),
-		Request:   request,
+		Request:   reqBytes,
 	}, c)
 
 	// Store a record of the vote choice change.

--- a/webapi/setvotechoices.go
+++ b/webapi/setvotechoices.go
@@ -134,7 +134,7 @@ func setVoteChoices(c *gin.Context) {
 	// Send success response to client.
 	resp, respSig := sendJSONResponse(setVoteChoicesResponse{
 		Timestamp: time.Now().Unix(),
-		Request:   request,
+		Request:   reqBytes,
 	}, c)
 
 	// Store a record of the vote choice change.

--- a/webapi/ticketstatus.go
+++ b/webapi/ticketstatus.go
@@ -36,7 +36,7 @@ func ticketStatus(c *gin.Context) {
 
 	sendJSONResponse(ticketStatusResponse{
 		Timestamp:       time.Now().Unix(),
-		Request:         request,
+		Request:         reqBytes,
 		TicketConfirmed: ticket.Confirmed,
 		FeeTxStatus:     string(ticket.FeeTxStatus),
 		FeeTxHash:       ticket.FeeTxHash,

--- a/webapi/types.go
+++ b/webapi/types.go
@@ -25,11 +25,11 @@ type feeAddressRequest struct {
 }
 
 type feeAddressResponse struct {
-	Timestamp  int64             `json:"timestamp"`
-	FeeAddress string            `json:"feeaddress"`
-	FeeAmount  int64             `json:"feeamount"`
-	Expiration int64             `json:"expiration"`
-	Request    feeAddressRequest `json:"request"`
+	Timestamp  int64  `json:"timestamp"`
+	FeeAddress string `json:"feeaddress"`
+	FeeAmount  int64  `json:"feeamount"`
+	Expiration int64  `json:"expiration"`
+	Request    []byte `json:"request"`
 }
 
 type payFeeRequest struct {
@@ -41,8 +41,8 @@ type payFeeRequest struct {
 }
 
 type payFeeResponse struct {
-	Timestamp int64         `json:"timestamp"`
-	Request   payFeeRequest `json:"request"`
+	Timestamp int64  `json:"timestamp"`
+	Request   []byte `json:"request"`
 }
 
 type setVoteChoicesRequest struct {
@@ -52,8 +52,8 @@ type setVoteChoicesRequest struct {
 }
 
 type setVoteChoicesResponse struct {
-	Timestamp int64                 `json:"timestamp"`
-	Request   setVoteChoicesRequest `json:"request"`
+	Timestamp int64  `json:"timestamp"`
+	Request   []byte `json:"request"`
 }
 
 type ticketStatusRequest struct {
@@ -61,10 +61,10 @@ type ticketStatusRequest struct {
 }
 
 type ticketStatusResponse struct {
-	Timestamp       int64               `json:"timestamp"`
-	TicketConfirmed bool                `json:"ticketconfirmed"`
-	FeeTxStatus     string              `json:"feetxstatus"`
-	FeeTxHash       string              `json:"feetxhash"`
-	VoteChoices     map[string]string   `json:"votechoices"`
-	Request         ticketStatusRequest `json:"request"`
+	Timestamp       int64             `json:"timestamp"`
+	TicketConfirmed bool              `json:"ticketconfirmed"`
+	FeeTxStatus     string            `json:"feetxstatus"`
+	FeeTxHash       string            `json:"feetxhash"`
+	VoteChoices     map[string]string `json:"votechoices"`
+	Request         []byte            `json:"request"`
 }


### PR DESCRIPTION
Reserializing the client request can result in different bytes because
the order of iteration over a map is not guaranteed to be the same every
time.