### PR TITLE
Store each ticket in its own DB bucket.

### DIFF
--- a/database/database.go
+++ b/database/database.go
@@ -85,6 +85,16 @@ func writeHotBackupFile(db *bolt.DB) error {
 	return err
 }
 
+func int64ToBytes(i int64) []byte {
+	bytes := make([]byte, 8)
+	binary.LittleEndian.PutUint64(bytes, uint64(i))
+	return bytes
+}
+
+func bytesToInt64(bytes []byte) int64 {
+	return int64(binary.LittleEndian.Uint64(bytes))
+}
+
 func uint32ToBytes(i uint32) []byte {
 	bytes := make([]byte, 4)
 	binary.LittleEndian.PutUint32(bytes, i)

--- a/database/ticket.go
+++ b/database/ticket.go
@@ -41,20 +41,20 @@ const (
 
 // The keys used to store ticket values in the database.
 var (
-	HashK              = []byte("Hash")
-	PurchaseHeightK    = []byte("PurchaseHeight")
-	CommitmentAddressK = []byte("CommitmentAddress")
-	FeeAddressIndexK   = []byte("FeeAddressIndex")
-	FeeAddressK        = []byte("FeeAddress")
-	FeeAmountK         = []byte("FeeAmount")
-	FeeExpirationK     = []byte("FeeExpiration")
-	ConfirmedK         = []byte("Confirmed")
-	VotingWIFK         = []byte("VotingWIF")
-	VoteChoicesK       = []byte("VoteChoices")
-	FeeTxHexK          = []byte("FeeTxHex")
-	FeeTxHashK         = []byte("FeeTxHash")
-	FeeTxStatusK       = []byte("FeeTxStatus")
-	OutcomeK           = []byte("Outcome")
+	hashK              = []byte("Hash")
+	purchaseHeightK    = []byte("PurchaseHeight")
+	commitmentAddressK = []byte("CommitmentAddress")
+	feeAddressIndexK   = []byte("FeeAddressIndex")
+	feeAddressK        = []byte("FeeAddress")
+	feeAmountK         = []byte("FeeAmount")
+	feeExpirationK     = []byte("FeeExpiration")
+	confirmedK         = []byte("Confirmed")
+	votingWIFK         = []byte("VotingWIF")
+	voteChoicesK       = []byte("VoteChoices")
+	feeTxHexK          = []byte("FeeTxHex")
+	feeTxHashK         = []byte("FeeTxHash")
+	feeTxStatusK       = []byte("FeeTxStatus")
+	outcomeK           = []byte("Outcome")
 )
 
 type Ticket struct {
@@ -113,7 +113,7 @@ func (vdb *VspDatabase) InsertNewTicket(ticket Ticket) error {
 		err = ticketBkt.ForEach(func(k, v []byte) error {
 			tbkt := ticketBkt.Bucket(k)
 
-			if string(tbkt.Get(FeeAddressK)) == ticket.FeeAddress {
+			if string(tbkt.Get(feeAddressK)) == ticket.FeeAddress {
 				return fmt.Errorf("ticket with fee address %s already exists", ticket.FeeAddress)
 			}
 
@@ -136,40 +136,40 @@ func (vdb *VspDatabase) InsertNewTicket(ticket Ticket) error {
 // array, and stores them as values within the provided db bucket.
 func putTicketInBucket(bkt *bolt.Bucket, ticket Ticket) error {
 	var err error
-	if err = bkt.Put(HashK, []byte(ticket.Hash)); err != nil {
+	if err = bkt.Put(hashK, []byte(ticket.Hash)); err != nil {
 		return err
 	}
-	if err = bkt.Put(CommitmentAddressK, []byte(ticket.CommitmentAddress)); err != nil {
+	if err = bkt.Put(commitmentAddressK, []byte(ticket.CommitmentAddress)); err != nil {
 		return err
 	}
-	if err = bkt.Put(FeeAddressK, []byte(ticket.FeeAddress)); err != nil {
+	if err = bkt.Put(feeAddressK, []byte(ticket.FeeAddress)); err != nil {
 		return err
 	}
-	if err = bkt.Put(VotingWIFK, []byte(ticket.VotingWIF)); err != nil {
+	if err = bkt.Put(votingWIFK, []byte(ticket.VotingWIF)); err != nil {
 		return err
 	}
-	if err = bkt.Put(FeeTxHexK, []byte(ticket.FeeTxHex)); err != nil {
+	if err = bkt.Put(feeTxHexK, []byte(ticket.FeeTxHex)); err != nil {
 		return err
 	}
-	if err = bkt.Put(FeeTxHashK, []byte(ticket.FeeTxHash)); err != nil {
+	if err = bkt.Put(feeTxHashK, []byte(ticket.FeeTxHash)); err != nil {
 		return err
 	}
-	if err = bkt.Put(FeeTxStatusK, []byte(ticket.FeeTxStatus)); err != nil {
+	if err = bkt.Put(feeTxStatusK, []byte(ticket.FeeTxStatus)); err != nil {
 		return err
 	}
-	if err = bkt.Put(OutcomeK, []byte(ticket.Outcome)); err != nil {
+	if err = bkt.Put(outcomeK, []byte(ticket.Outcome)); err != nil {
 		return err
 	}
-	if err = bkt.Put(PurchaseHeightK, int64ToBytes(ticket.PurchaseHeight)); err != nil {
+	if err = bkt.Put(purchaseHeightK, int64ToBytes(ticket.PurchaseHeight)); err != nil {
 		return err
 	}
-	if err = bkt.Put(FeeAddressIndexK, uint32ToBytes(ticket.FeeAddressIndex)); err != nil {
+	if err = bkt.Put(feeAddressIndexK, uint32ToBytes(ticket.FeeAddressIndex)); err != nil {
 		return err
 	}
-	if err = bkt.Put(FeeAmountK, int64ToBytes(ticket.FeeAmount)); err != nil {
+	if err = bkt.Put(feeAmountK, int64ToBytes(ticket.FeeAmount)); err != nil {
 		return err
 	}
-	if err = bkt.Put(FeeExpirationK, int64ToBytes(ticket.FeeExpiration)); err != nil {
+	if err = bkt.Put(feeExpirationK, int64ToBytes(ticket.FeeExpiration)); err != nil {
 		return err
 	}
 
@@ -177,7 +177,7 @@ func putTicketInBucket(bkt *bolt.Bucket, ticket Ticket) error {
 	if ticket.Confirmed {
 		confirmed = []byte{1}
 	}
-	if err = bkt.Put(ConfirmedK, confirmed); err != nil {
+	if err = bkt.Put(confirmedK, confirmed); err != nil {
 		return err
 	}
 
@@ -185,7 +185,7 @@ func putTicketInBucket(bkt *bolt.Bucket, ticket Ticket) error {
 	if err != nil {
 		return err
 	}
-	if err = bkt.Put(VoteChoicesK, jsonVoteChoices); err != nil {
+	if err = bkt.Put(voteChoicesK, jsonVoteChoices); err != nil {
 		return err
 	}
 
@@ -195,27 +195,27 @@ func putTicketInBucket(bkt *bolt.Bucket, ticket Ticket) error {
 func getTicketFromBkt(bkt *bolt.Bucket) (Ticket, error) {
 	var ticket Ticket
 
-	ticket.Hash = string(bkt.Get(HashK))
-	ticket.CommitmentAddress = string(bkt.Get(CommitmentAddressK))
-	ticket.FeeAddress = string(bkt.Get(FeeAddressK))
-	ticket.VotingWIF = string(bkt.Get(VotingWIFK))
-	ticket.FeeTxHex = string(bkt.Get(FeeTxHexK))
-	ticket.FeeTxHash = string(bkt.Get(FeeTxHashK))
-	ticket.FeeTxStatus = FeeStatus(bkt.Get(FeeTxStatusK))
-	ticket.Outcome = TicketOutcome(bkt.Get(OutcomeK))
+	ticket.Hash = string(bkt.Get(hashK))
+	ticket.CommitmentAddress = string(bkt.Get(commitmentAddressK))
+	ticket.FeeAddress = string(bkt.Get(feeAddressK))
+	ticket.VotingWIF = string(bkt.Get(votingWIFK))
+	ticket.FeeTxHex = string(bkt.Get(feeTxHexK))
+	ticket.FeeTxHash = string(bkt.Get(feeTxHashK))
+	ticket.FeeTxStatus = FeeStatus(bkt.Get(feeTxStatusK))
+	ticket.Outcome = TicketOutcome(bkt.Get(outcomeK))
 
-	ticket.PurchaseHeight = bytesToInt64(bkt.Get(PurchaseHeightK))
-	ticket.FeeAddressIndex = bytesToUint32(bkt.Get(FeeAddressIndexK))
-	ticket.FeeAmount = bytesToInt64(bkt.Get(FeeAmountK))
-	ticket.FeeExpiration = bytesToInt64(bkt.Get(FeeExpirationK))
+	ticket.PurchaseHeight = bytesToInt64(bkt.Get(purchaseHeightK))
+	ticket.FeeAddressIndex = bytesToUint32(bkt.Get(feeAddressIndexK))
+	ticket.FeeAmount = bytesToInt64(bkt.Get(feeAmountK))
+	ticket.FeeExpiration = bytesToInt64(bkt.Get(feeExpirationK))
 
 	// TODO is this dodgy?
-	if bkt.Get(ConfirmedK)[0] == byte(1) {
+	if bkt.Get(confirmedK)[0] == byte(1) {
 		ticket.Confirmed = true
 	}
 
 	voteChoices := make(map[string]string)
-	err := json.Unmarshal(bkt.Get(VoteChoicesK), &voteChoices)
+	err := json.Unmarshal(bkt.Get(voteChoicesK), &voteChoices)
 	if err != nil {
 		return ticket, err
 	}
@@ -298,8 +298,8 @@ func (vdb *VspDatabase) CountTickets() (int64, int64, int64, error) {
 		return ticketBkt.ForEach(func(k, v []byte) error {
 			tBkt := ticketBkt.Bucket(k)
 
-			if FeeStatus(tBkt.Get(FeeTxStatusK)) == FeeConfirmed {
-				switch TicketOutcome(tBkt.Get(OutcomeK)) {
+			if FeeStatus(tBkt.Get(feeTxStatusK)) == FeeConfirmed {
+				switch TicketOutcome(tBkt.Get(outcomeK)) {
 				case Voted:
 					voted++
 				case Revoked:

--- a/database/ticket.go
+++ b/database/ticket.go
@@ -185,11 +185,7 @@ func putTicketInBucket(bkt *bolt.Bucket, ticket Ticket) error {
 	if err != nil {
 		return err
 	}
-	if err = bkt.Put(voteChoicesK, jsonVoteChoices); err != nil {
-		return err
-	}
-
-	return nil
+	return bkt.Put(voteChoicesK, jsonVoteChoices)
 }
 
 func getTicketFromBkt(bkt *bolt.Bucket) (Ticket, error) {

--- a/database/ticket_test.go
+++ b/database/ticket_test.go
@@ -159,12 +159,14 @@ func testUpdateTicket(t *testing.T) {
 	// Update ticket with new values.
 	ticket.FeeAmount = ticket.FeeAmount + 1
 	ticket.FeeExpiration = ticket.FeeExpiration + 1
+	ticket.VoteChoices = map[string]string{"New agenda": "New value"}
+
 	err = db.UpdateTicket(ticket)
 	if err != nil {
 		t.Fatalf("error updating ticket: %v", err)
 	}
 
-	// Retrieve ticket from database.
+	// Retrieve updated ticket from database.
 	retrieved, found, err := db.GetTicketByHash(ticket.Hash)
 	if err != nil {
 		t.Fatalf("error retrieving ticket by ticket hash: %v", err)
@@ -174,7 +176,8 @@ func testUpdateTicket(t *testing.T) {
 	}
 
 	if ticket.FeeAmount != retrieved.FeeAmount ||
-		ticket.FeeExpiration != retrieved.FeeExpiration {
+		ticket.FeeExpiration != retrieved.FeeExpiration ||
+		!reflect.DeepEqual(retrieved.VoteChoices, ticket.VoteChoices) {
 		t.Fatal("retrieved ticket value didnt match expected")
 	}
 

--- a/database/upgrade_v2.go
+++ b/database/upgrade_v2.go
@@ -19,7 +19,7 @@ func removeOldFeeTxUpgrade(db *bolt.DB) error {
 		count := 0
 		err := ticketBkt.ForEach(func(k, v []byte) error {
 			// Deserialize the old ticket.
-			var ticket Ticket
+			var ticket v1Ticket
 			err := json.Unmarshal(v, &ticket)
 			if err != nil {
 				return fmt.Errorf("could not unmarshal ticket: %w", err)
@@ -51,7 +51,7 @@ func removeOldFeeTxUpgrade(db *bolt.DB) error {
 		// Update database version.
 		err = vspBkt.Put(versionK, uint32ToBytes(removeOldFeeTxVersion))
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to update db version: %w", err)
 		}
 
 		return nil

--- a/database/upgrades.go
+++ b/database/upgrades.go
@@ -16,16 +16,41 @@ const (
 	// need to keep these, and they take up a lot of space.
 	removeOldFeeTxVersion = 2
 
+	// ticketBucketVersion changes the way tickets are stored. Previously they
+	// were stored as JSON encoded strings in a single bucket. This upgrade
+	// moves each ticket into its own bucket and does away with JSON encoding.
+	ticketBucketVersion = 3
+
 	// latestVersion is the latest version of the database that is understood by
 	// vspd. Databases with recorded versions higher than this will fail to open
 	// (meaning any upgrades prevent reverting to older software).
-	latestVersion = removeOldFeeTxVersion
+	latestVersion = ticketBucketVersion
 )
 
 // upgrades maps between old database versions and the upgrade function to
 // upgrade the database to the next version.
 var upgrades = []func(tx *bolt.DB) error{
-	initialVersion: removeOldFeeTxUpgrade,
+	initialVersion:        removeOldFeeTxUpgrade,
+	removeOldFeeTxVersion: ticketBucketUpgrade,
+}
+
+// v1Ticket has the json tags required to unmarshal tickets stored in the
+// v1 database format.
+type v1Ticket struct {
+	Hash              string            `json:"hsh"`
+	PurchaseHeight    int64             `json:"phgt"`
+	CommitmentAddress string            `json:"cmtaddr"`
+	FeeAddressIndex   uint32            `json:"faddridx"`
+	FeeAddress        string            `json:"faddr"`
+	FeeAmount         int64             `json:"famt"`
+	FeeExpiration     int64             `json:"fexp"`
+	Confirmed         bool              `json:"conf"`
+	VotingWIF         string            `json:"vwif"`
+	VoteChoices       map[string]string `json:"vchces"`
+	FeeTxHex          string            `json:"fhex"`
+	FeeTxHash         string            `json:"fhsh"`
+	FeeTxStatus       FeeStatus         `json:"fsts"`
+	Outcome           TicketOutcome     `json:"otcme"`
 }
 
 // Upgrade will update the database to the latest known version.

--- a/webapi/getfeeaddress.go
+++ b/webapi/getfeeaddress.go
@@ -89,9 +89,10 @@ func feeAddress(c *gin.Context) {
 	ticketHash := request.TicketHash
 
 	// Respond early if we already have the fee tx for this ticket.
-	if ticket.FeeTxStatus == database.FeeReceieved ||
-		ticket.FeeTxStatus == database.FeeBroadcast ||
-		ticket.FeeTxStatus == database.FeeConfirmed {
+	if knownTicket &&
+		(ticket.FeeTxStatus == database.FeeReceieved ||
+			ticket.FeeTxStatus == database.FeeBroadcast ||
+			ticket.FeeTxStatus == database.FeeConfirmed) {
 		log.Warnf("%s: Fee tx already received (clientIP=%s, ticketHash=%s)",
 			funcName, c.ClientIP(), ticket.Hash)
 		sendError(errFeeAlreadyReceived, c)


### PR DESCRIPTION
**NOTE: This contains a backwards incompatible database migration, so if you plan to test it, please make a copy of your database first.**

Moves tickets from a single database bucket containing JSON encoded strings, to a bucket for each ticket.

This change is to preemptively deal with scaling issues seen with databases containing tens of thousands of tickets. (Closes #223)