### PR TITLE
Add block explorer links

### DIFF
--- a/params.go
+++ b/params.go
@@ -33,5 +33,5 @@ var simNetParams = netParams{
 	Params:              chaincfg.SimNetParams(),
 	DcrdRPCServerPort:   "19556",
 	WalletRPCServerPort: "19557",
-	BlockExplorerURL:    "https://dcrdata.decred.org",
+	BlockExplorerURL:    "...",
 }

--- a/params.go
+++ b/params.go
@@ -12,22 +12,26 @@ type netParams struct {
 	*chaincfg.Params
 	DcrdRPCServerPort   string
 	WalletRPCServerPort string
+	BlockExplorerURL    string
 }
 
 var mainNetParams = netParams{
 	Params:              chaincfg.MainNetParams(),
 	DcrdRPCServerPort:   "9109",
 	WalletRPCServerPort: "9110",
+	BlockExplorerURL:    "https://dcrdata.decred.org",
 }
 
 var testNet3Params = netParams{
 	Params:              chaincfg.TestNet3Params(),
 	DcrdRPCServerPort:   "19109",
 	WalletRPCServerPort: "19110",
+	BlockExplorerURL:    "https://testnet.dcrdata.org",
 }
 
 var simNetParams = netParams{
 	Params:              chaincfg.SimNetParams(),
 	DcrdRPCServerPort:   "19556",
 	WalletRPCServerPort: "19557",
+	BlockExplorerURL:    "https://dcrdata.decred.org",
 }

--- a/vspd.go
+++ b/vspd.go
@@ -87,6 +87,7 @@ func run(ctx context.Context) error {
 	apiCfg := webapi.Config{
 		VSPFee:               cfg.VSPFee,
 		NetParams:            cfg.netParams.Params,
+		BlockExplorerURL:     cfg.netParams.BlockExplorerURL,
 		SupportEmail:         cfg.SupportEmail,
 		VspClosed:            cfg.VspClosed,
 		AdminPass:            cfg.AdminPass,

--- a/webapi/admin.go
+++ b/webapi/admin.go
@@ -7,6 +7,7 @@ package webapi
 import (
 	"net/http"
 
+	"github.com/decred/vspd/database"
 	"github.com/decred/vspd/rpc"
 	"github.com/gin-gonic/gin"
 	"github.com/gorilla/sessions"
@@ -24,6 +25,14 @@ type WalletStatus struct {
 	Voting          bool   `json:"voting"`
 	BestBlockError  bool   `json:"bestblockerror"`
 	BestBlockHeight int64  `json:"bestblockheight"`
+}
+
+type searchResult struct {
+	Hash           string
+	Found          bool
+	Ticket         database.Ticket
+	VoteChanges    map[uint32]database.VoteChangeRecord
+	MaxVoteChanges int
 }
 
 func walletStatus(c *gin.Context) map[string]WalletStatus {
@@ -113,12 +122,12 @@ func ticketSearch(c *gin.Context) {
 	}
 
 	c.HTML(http.StatusOK, "admin.html", gin.H{
-		"SearchResult": gin.H{
-			"Hash":           hash,
-			"Found":          found,
-			"Ticket":         ticket,
-			"VoteChanges":    voteChanges,
-			"MaxVoteChanges": cfg.MaxVoteChangeRecords,
+		"SearchResult": searchResult{
+			Hash:           hash,
+			Found:          found,
+			Ticket:         ticket,
+			VoteChanges:    voteChanges,
+			MaxVoteChanges: cfg.MaxVoteChangeRecords,
 		},
 		"VspStats":     getVSPStats(),
 		"WalletStatus": walletStatus(c),

--- a/webapi/formatting.go
+++ b/webapi/formatting.go
@@ -1,5 +1,7 @@
 package webapi
 
+import "time"
+
 func addressURL(blockExplorerURL string) func(string) string {
 	return func(addr string) string {
 		return blockExplorerURL + "/address/" + addr
@@ -10,4 +12,8 @@ func txURL(blockExplorerURL string) func(string) string {
 	return func(txID string) string {
 		return blockExplorerURL + "/tx/" + txID
 	}
+}
+
+func dateTime(t int64) string {
+	return time.Unix(t, 0).Format("2 Jan 2006 15:04:05")
 }

--- a/webapi/formatting.go
+++ b/webapi/formatting.go
@@ -1,0 +1,13 @@
+package webapi
+
+func addressURL(blockExplorerURL string) func(string) string {
+	return func(addr string) string {
+		return blockExplorerURL + "/address/" + addr
+	}
+}
+
+func txURL(blockExplorerURL string) func(string) string {
+	return func(txID string) string {
+		return blockExplorerURL + "/tx/" + txID
+	}
+}

--- a/webapi/homepage.go
+++ b/webapi/homepage.go
@@ -55,7 +55,7 @@ func updateVSPStats(db *database.VspDatabase, cfg Config) error {
 		Revoked:      revoked,
 		VSPFee:       cfg.VSPFee,
 		Network:      cfg.NetParams.Name,
-		UpdateTime:   time.Now().Format("Mon Jan _2 15:04:05 2006"),
+		UpdateTime:   dateTime(time.Now().Unix()),
 		SupportEmail: cfg.SupportEmail,
 		VspClosed:    cfg.VspClosed,
 		Debug:        cfg.Debug,

--- a/webapi/templates/admin.html
+++ b/webapi/templates/admin.html
@@ -125,7 +125,7 @@
                             </tr>
                             <tr>
                                 <th>Fee Expiration</th>
-                                <td>{{ .Ticket.FeeExpiration }}</td>
+                                <td>{{ .Ticket.FeeExpiration }} ({{ dateTime .Ticket.FeeExpiration }}) </td>
                             </tr>
                             <tr>
                                 <th>Confirmed</th>

--- a/webapi/templates/admin.html
+++ b/webapi/templates/admin.html
@@ -97,7 +97,11 @@
                         <table class="table ticket-table mt-2 mb-4">
                             <tr>
                                 <th>Hash</th>
-                                <td>{{ .Ticket.Hash }}</td>
+                                <td>
+                                    <a href="{{ txURL .Ticket.Hash }}">
+                                        {{ .Ticket.Hash }}
+                                    </a>
+                                </td>
                             </tr>
                             <tr>
                                 <th>Commitment Address</th>
@@ -109,7 +113,11 @@
                             </tr>
                             <tr>
                                 <th>Fee Address</th>
-                                <td>{{ .Ticket.FeeAddress }}</td>
+                                <td>
+                                    <a href="{{ addressURL .Ticket.FeeAddress }}">
+                                        {{ .Ticket.FeeAddress }}
+                                    </a>
+                                </td>
                             </tr>
                             <tr>
                                 <th>Fee Amount</th>
@@ -173,12 +181,16 @@
                                 <td>{{ .Ticket.VotingWIF }}</td>
                             </tr>
                             <tr>
-                                <th>Fee Tx</th>
-                                <td>{{ .Ticket.FeeTxHex }}</td>
+                                <th>Fee Tx Hash</th>
+                                <td>
+                                    <a href="{{ txURL .Ticket.FeeTxHash }}">
+                                        {{ .Ticket.FeeTxHash }}
+                                    </a>
+                                </td>
                             </tr>
                             <tr>
-                                <th>Fee Tx Hash</th>
-                                <td>{{ .Ticket.FeeTxHash }}</td>
+                                <th>Fee Tx</th>
+                                <td>{{ .Ticket.FeeTxHex }}</td>
                             </tr>
                             <tr>
                                 <th>Fee Tx Status</th>

--- a/webapi/webapi.go
+++ b/webapi/webapi.go
@@ -11,6 +11,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"html/template"
 	"net"
 	"net/http"
 	"sync"
@@ -26,6 +27,7 @@ import (
 type Config struct {
 	VSPFee               float64
 	NetParams            *chaincfg.Params
+	BlockExplorerURL     string
 	FeeAccountName       string
 	SupportEmail         string
 	VspClosed            bool
@@ -173,6 +175,14 @@ func router(debugMode bool, cookieSecret []byte, dcrd rpc.DcrdConnect, wallets r
 	}
 
 	router := gin.New()
+
+	// Add custom functions for use in templates.
+	router.SetFuncMap(template.FuncMap{
+		"txURL":      txURL(cfg.BlockExplorerURL),
+		"blockURL":   blockURL(cfg.BlockExplorerURL),
+		"addressURL": addressURL(cfg.BlockExplorerURL),
+	})
+
 	router.LoadHTMLGlob("webapi/templates/*.html")
 
 	// Recovery middleware handles any go panics generated while processing web

--- a/webapi/webapi.go
+++ b/webapi/webapi.go
@@ -179,8 +179,8 @@ func router(debugMode bool, cookieSecret []byte, dcrd rpc.DcrdConnect, wallets r
 	// Add custom functions for use in templates.
 	router.SetFuncMap(template.FuncMap{
 		"txURL":      txURL(cfg.BlockExplorerURL),
-		"blockURL":   blockURL(cfg.BlockExplorerURL),
 		"addressURL": addressURL(cfg.BlockExplorerURL),
+		"dateTime":   dateTime,
 	})
 
 	router.LoadHTMLGlob("webapi/templates/*.html")


### PR DESCRIPTION
- Add block explorer links for ticket hash, fee address and fee tx hash.
- Add a formatted date/time for fee expiration rather than only showing unix timestamp.

Closes #245 