### PR TITLE
Make log rotator params configurable.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 ISC License
 
-Copyright (c) 2020 The Decred developers
+Copyright (c) 2020-2021 The Decred developers
 
 Permission to use, copy, modify, and distribute this software for any
 purpose with or without fee is hereby granted, provided that the above

--- a/config.go
+++ b/config.go
@@ -27,6 +27,8 @@ import (
 var (
 	defaultListen         = ":8800"
 	defaultLogLevel       = "debug"
+	defaultMaxLogSize     = int64(10)
+	defaultLogsToKeep     = 20
 	defaultVSPFee         = 3.0
 	defaultNetwork        = "testnet"
 	defaultHomeDir        = dcrutil.AppDataDir("vspd", false)
@@ -44,6 +46,8 @@ var (
 type config struct {
 	Listen          string        `long:"listen" ini-name:"listen" description:"The ip:port to listen for API requests."`
 	LogLevel        string        `long:"loglevel" ini-name:"loglevel" description:"Logging level." choice:"trace" choice:"debug" choice:"info" choice:"warn" choice:"error" choice:"critical"`
+	MaxLogSize      int64         `long:"maxlogsize" ini-name:"maxlogsize" description:"File size threshold for log file rotation (MB)."`
+	LogsToKeep      int           `long:"logstokeep" ini-name:"logstokeep" description:"The number of rotated log files to keep."`
 	Network         string        `long:"network" ini-name:"network" description:"Decred network to use." choice:"testnet" choice:"mainnet" choice:"simnet"`
 	VSPFee          float64       `long:"vspfee" ini-name:"vspfee" description:"Fee percentage charged for VSP use. eg. 2.0 (2%), 0.5 (0.5%)."`
 	DcrdHost        string        `long:"dcrdhost" ini-name:"dcrdhost" description:"The ip:port to establish a JSON-RPC connection with dcrd. Should be the same host where vspd is running."`
@@ -164,6 +168,8 @@ func loadConfig() (*config, error) {
 	cfg := config{
 		Listen:         defaultListen,
 		LogLevel:       defaultLogLevel,
+		MaxLogSize:     defaultMaxLogSize,
+		LogsToKeep:     defaultLogsToKeep,
 		Network:        defaultNetwork,
 		VSPFee:         defaultVSPFee,
 		HomeDir:        defaultHomeDir,
@@ -392,7 +398,7 @@ func loadConfig() (*config, error) {
 
 	// Initialize loggers and log rotation.
 	logDir := filepath.Join(cfg.HomeDir, "logs", cfg.netParams.Name)
-	initLogRotator(filepath.Join(logDir, "vspd.log"))
+	initLogRotator(filepath.Join(logDir, "vspd.log"), cfg.MaxLogSize, cfg.LogsToKeep)
 	setLogLevels(cfg.LogLevel)
 
 	// Set the database path

--- a/log.go
+++ b/log.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Decred developers
+// Copyright (c) 2020-2021 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -72,14 +72,14 @@ var subsystemLoggers = map[string]slog.Logger{
 // initLogRotator initializes the logging rotater to write logs to logFile and
 // create roll files in the same directory.  It must be called before the
 // package-global log rotater variables are used.
-func initLogRotator(logFile string) {
+func initLogRotator(logFile string, maxLogSize int64, logsToKeep int) {
 	logDir, _ := filepath.Split(logFile)
 	err := os.MkdirAll(logDir, 0700)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to create log directory: %v\n", err)
 		os.Exit(1)
 	}
-	r, err := rotator.New(logFile, 10*1024, false, 3)
+	r, err := rotator.New(logFile, maxLogSize*1024, false, logsToKeep)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to create file rotator: %v\n", err)
 		os.Exit(1)

--- a/webapi/templates/footer.html
+++ b/webapi/templates/footer.html
@@ -15,7 +15,7 @@
 
         <div class="col-md-4 col-12 footer__credit d-flex justify-content-center align-items-center">
             <p class="py-4 m-0">
-                Decred Developers | 2020
+                Decred Developers | 2020-2021
                 <br />
                 The source code is available on <a href="https://github.com/decred/vspd" target="_blank" rel="noopener noreferrer">GitHub</a>
             </p>


### PR DESCRIPTION
Maintaining the dafault max log file size of 10MB, but increasing the default number of retained files from 3 to 20.

Closes #244.