### PR TITLE
Set and display ticket purchase height

### DIFF
--- a/webapi/formatting.go
+++ b/webapi/formatting.go
@@ -1,16 +1,25 @@
 package webapi
 
-import "time"
+import (
+	"fmt"
+	"time"
+)
 
 func addressURL(blockExplorerURL string) func(string) string {
 	return func(addr string) string {
-		return blockExplorerURL + "/address/" + addr
+		return fmt.Sprintf("%s/address/%s", blockExplorerURL, addr)
 	}
 }
 
 func txURL(blockExplorerURL string) func(string) string {
 	return func(txID string) string {
-		return blockExplorerURL + "/tx/" + txID
+		return fmt.Sprintf("%s/tx/%s", blockExplorerURL, txID)
+	}
+}
+
+func blockURL(blockExplorerURL string) func(int64) string {
+	return func(height int64) string {
+		return fmt.Sprintf("%s/block/%d", blockExplorerURL, height)
 	}
 }
 

--- a/webapi/getfeeaddress.go
+++ b/webapi/getfeeaddress.go
@@ -176,10 +176,18 @@ func feeAddress(c *gin.Context) {
 	now := time.Now()
 	expire := now.Add(feeAddressExpiration).Unix()
 
-	confirmed := rawTicket.Confirmations >= requiredConfs
+	// Only set purchase height if the ticket already has 6 confs, otherwise its
+	// purchase height may change due to reorgs.
+	confirmed := false
+	purchaseHeight := int64(0)
+	if rawTicket.Confirmations >= requiredConfs {
+		confirmed = true
+		purchaseHeight = rawTicket.BlockHeight
+	}
 
 	dbTicket := database.Ticket{
 		Hash:              ticketHash,
+		PurchaseHeight:    purchaseHeight,
 		CommitmentAddress: commitmentAddress,
 		FeeAddressIndex:   newAddressIdx,
 		FeeAddress:        newAddress,

--- a/webapi/payfee.go
+++ b/webapi/payfee.go
@@ -214,7 +214,7 @@ findAddress:
 
 	// At this point we are satisfied that the request is valid and the fee tx
 	// pays sufficient fees to the expected address. Proceed to update the
-	// database, and if the ticket is confirmed broadcast the transaction.
+	// database, and if the ticket is confirmed broadcast the fee transaction.
 
 	ticket.VotingWIF = votingWIF.String()
 	ticket.FeeTxHex = request.FeeTx

--- a/webapi/templates/admin.html
+++ b/webapi/templates/admin.html
@@ -104,6 +104,17 @@
                                 </td>
                             </tr>
                             <tr>
+                                <th>Status</th>
+                                {{ if .Ticket.Confirmed }}
+                                    <td>
+                                        Confirmed (purchase height: 
+                                        <a href="{{ blockURL .Ticket.PurchaseHeight }}">{{ .Ticket.PurchaseHeight }}</a>)
+                                    </td>
+                                {{ else }}
+                                    <td>Not confirmed</td>
+                                {{ end }}
+                            </tr>
+                            <tr>
                                 <th>Commitment Address</th>
                                 <td>{{ .Ticket.CommitmentAddress }}</td>
                             </tr>
@@ -126,10 +137,6 @@
                             <tr>
                                 <th>Fee Expiration</th>
                                 <td>{{ .Ticket.FeeExpiration }} ({{ dateTime .Ticket.FeeExpiration }}) </td>
-                            </tr>
-                            <tr>
-                                <th>Confirmed</th>
-                                <td>{{ .Ticket.Confirmed }}</td>
                             </tr>
                             <tr>
                                 <th>Current Vote Choices</th>

--- a/webapi/webapi.go
+++ b/webapi/webapi.go
@@ -180,6 +180,7 @@ func router(debugMode bool, cookieSecret []byte, dcrd rpc.DcrdConnect, wallets r
 	router.SetFuncMap(template.FuncMap{
 		"txURL":      txURL(cfg.BlockExplorerURL),
 		"addressURL": addressURL(cfg.BlockExplorerURL),
+		"blockURL":   blockURL(cfg.BlockExplorerURL),
 		"dateTime":   dateTime,
 	})
 


### PR DESCRIPTION
I had an ulterior motive when splitting this work out from #245. I suspected that purchase height was not being set correctly in all cases, and I was correct. It was only being set for tickets which were not already mature when added to the VSP, and it was never set for already mature ticket. The first commit in this PR fixes that bug.

The second commit displays the purchase height in the admin page with a link to the block explorer. Purchase height is only shown when the ticket is confirmed because if a ticket is not confirmed, its purchase height is not yet known.