### PR TITLE
Use a custom Recovery middleware.

### DIFF
--- a/webapi/middleware.go
+++ b/webapi/middleware.go
@@ -103,7 +103,7 @@ func withWalletClients(wallets rpc.WalletConnect) gin.HandlerFunc {
 }
 
 // drainAndReplaceBody will read and return the body of the provided request. It
-// replaces the request reader with an identical so it can be used again.
+// replaces the request reader with an identical one so it can be used again.
 func drainAndReplaceBody(req *http.Request) ([]byte, error) {
 	reqBytes, err := ioutil.ReadAll(req.Body)
 	if err != nil {

--- a/webapi/middleware.go
+++ b/webapi/middleware.go
@@ -102,6 +102,18 @@ func withWalletClients(wallets rpc.WalletConnect) gin.HandlerFunc {
 	}
 }
 
+// drainAndReplaceBody will read and return the body of the provided request. It
+// replaces the request reader with an identical so it can be used again.
+func drainAndReplaceBody(req *http.Request) ([]byte, error) {
+	reqBytes, err := ioutil.ReadAll(req.Body)
+	if err != nil {
+		return nil, err
+	}
+	req.Body.Close()
+	req.Body = ioutil.NopCloser(bytes.NewBuffer(reqBytes))
+	return reqBytes, nil
+}
+
 // broadcastTicket will ensure that the local dcrd instance is aware of the
 // provided ticket.
 // Ticket hash, ticket hex, and parent hex are parsed from the request body and
@@ -111,16 +123,13 @@ func broadcastTicket() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		const funcName = "broadcastTicket"
 
-		// Read request bytes and then replace the request reader for
-		// downstream handlers to use.
-		reqBytes, err := ioutil.ReadAll(c.Request.Body)
+		// Read request bytes.
+		reqBytes, err := drainAndReplaceBody(c.Request)
 		if err != nil {
 			log.Warnf("%s: Error reading request (clientIP=%s): %v", funcName, c.ClientIP(), err)
 			sendErrorWithMsg(err.Error(), errBadRequest, c)
 			return
 		}
-		c.Request.Body.Close()
-		c.Request.Body = ioutil.NopCloser(bytes.NewBuffer(reqBytes))
 
 		// Parse request to ensure ticket hash/hex and parent hex are included.
 		var request struct {
@@ -249,7 +258,7 @@ func vspAuth() gin.HandlerFunc {
 		const funcName = "vspAuth"
 
 		// Read request bytes.
-		reqBytes, err := ioutil.ReadAll(c.Request.Body)
+		reqBytes, err := drainAndReplaceBody(c.Request)
 		if err != nil {
 			log.Warnf("%s: Error reading request (clientIP=%s): %v", funcName, c.ClientIP(), err)
 			sendErrorWithMsg(err.Error(), errBadRequest, c)

--- a/webapi/recovery.go
+++ b/webapi/recovery.go
@@ -14,8 +14,10 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-// Recovery returns a middleware for a given writer that recovers from any
-// panics and calls the provided handle func to handle it.
+// Recovery returns a middleware that recovers from any panics which occur in
+// request handlers. It logs the panic, a stack trace, and the full request
+// details. It also ensure the client receives a 500 response rather than no
+// response at all.
 func Recovery() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		defer func() {
@@ -53,11 +55,11 @@ func Recovery() gin.HandlerFunc {
 	}
 }
 
-// formattedStack returns a nicely formatted formattedStack frame.
+// formattedStack returns a nicely formatted stack frame.
 func formattedStack() []byte {
-	buf := new(bytes.Buffer) // the returned data
-	// As we loop, we open files and read them. These variables record the currently
-	// loaded file.
+	buf := new(bytes.Buffer)
+	// As we loop, we open files and read them. These variables record the
+	// currently loaded file.
 	var lines [][]byte
 	var lastFile string
 	for i := 3; ; i++ {
@@ -65,7 +67,7 @@ func formattedStack() []byte {
 		if !ok {
 			break
 		}
-		// Print this much at least.  If we can't find the source, it won't show.
+		// Print this much at least. If we can't find the source, it won't show.
 		fmt.Fprintf(buf, "%s:%d (0x%x)\n", file, line, pc)
 		if file != lastFile {
 			data, err := ioutil.ReadFile(file)
@@ -97,12 +99,12 @@ func function(pc uintptr) []byte {
 	}
 	name := []byte(fn.Name())
 	// The name includes the path name to the package, which is unnecessary
-	// since the file name is already included.  Plus, it has center dots.
+	// since the file name is already included. Plus, it has center dots.
 	// That is, we see
 	//	runtime/debug.*T·ptrmethod
 	// and want
 	//	*T.ptrmethod
-	// Also the package path might contains dot (e.g. code.google.com/...),
+	// Also the package path might contain dot (e.g. code.google.com/...),
 	// so first eliminate the path prefix
 	if lastSlash := bytes.LastIndex(name, []byte("/")); lastSlash >= 0 {
 		name = name[lastSlash+1:]

--- a/webapi/recovery.go
+++ b/webapi/recovery.go
@@ -1,0 +1,115 @@
+package webapi
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"net/http/httputil"
+	"os"
+	"runtime"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+)
+
+// Recovery returns a middleware for a given writer that recovers from any
+// panics and calls the provided handle func to handle it.
+func Recovery() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		defer func() {
+			if err := recover(); err != nil {
+				// Check for a broken connection, as it is not really a
+				// condition that warrants a panic stack trace.
+				var brokenPipe bool
+				if ne, ok := err.(*net.OpError); ok {
+					if se, ok := ne.Err.(*os.SyscallError); ok {
+						if strings.Contains(strings.ToLower(se.Error()), "broken pipe") ||
+							strings.Contains(strings.ToLower(se.Error()), "connection reset by peer") {
+							brokenPipe = true
+						}
+					}
+				}
+
+				httpRequest, _ := httputil.DumpRequest(c.Request, true)
+				if brokenPipe {
+					log.Errorf("%s\n%s", err, httpRequest)
+				} else {
+					log.Errorf("panic recovered: %s\n\n%s\n\n%s",
+						err, formattedStack(), httpRequest)
+				}
+
+				if brokenPipe {
+					// If the connection is dead, we can't write a status to it.
+					_ = c.Error(err.(error))
+					c.Abort()
+				} else {
+					c.AbortWithStatus(http.StatusInternalServerError)
+				}
+			}
+		}()
+		c.Next()
+	}
+}
+
+// formattedStack returns a nicely formatted formattedStack frame.
+func formattedStack() []byte {
+	buf := new(bytes.Buffer) // the returned data
+	// As we loop, we open files and read them. These variables record the currently
+	// loaded file.
+	var lines [][]byte
+	var lastFile string
+	for i := 3; ; i++ {
+		pc, file, line, ok := runtime.Caller(i)
+		if !ok {
+			break
+		}
+		// Print this much at least.  If we can't find the source, it won't show.
+		fmt.Fprintf(buf, "%s:%d (0x%x)\n", file, line, pc)
+		if file != lastFile {
+			data, err := ioutil.ReadFile(file)
+			if err != nil {
+				continue
+			}
+			lines = bytes.Split(data, []byte{'\n'})
+			lastFile = file
+		}
+		fmt.Fprintf(buf, "\t%s: %s\n", function(pc), source(lines, line))
+	}
+	return buf.Bytes()
+}
+
+// source returns a space-trimmed slice of the n'th line.
+func source(lines [][]byte, n int) []byte {
+	n-- // in stack trace, lines are 1-indexed but our array is 0-indexed
+	if n < 0 || n >= len(lines) {
+		return []byte("???")
+	}
+	return bytes.TrimSpace(lines[n])
+}
+
+// function returns, if possible, the name of the function containing the PC.
+func function(pc uintptr) []byte {
+	fn := runtime.FuncForPC(pc)
+	if fn == nil {
+		return []byte("???")
+	}
+	name := []byte(fn.Name())
+	// The name includes the path name to the package, which is unnecessary
+	// since the file name is already included.  Plus, it has center dots.
+	// That is, we see
+	//	runtime/debug.*T·ptrmethod
+	// and want
+	//	*T.ptrmethod
+	// Also the package path might contains dot (e.g. code.google.com/...),
+	// so first eliminate the path prefix
+	if lastSlash := bytes.LastIndex(name, []byte("/")); lastSlash >= 0 {
+		name = name[lastSlash+1:]
+	}
+	if period := bytes.Index(name, []byte(".")); period >= 0 {
+		name = name[period+1:]
+	}
+	name = bytes.Replace(name, []byte("·"), []byte("."), -1)
+	return name
+}

--- a/webapi/webapi.go
+++ b/webapi/webapi.go
@@ -188,7 +188,7 @@ func router(debugMode bool, cookieSecret []byte, dcrd rpc.DcrdConnect, wallets r
 	// Recovery middleware handles any go panics generated while processing web
 	// requests. Ensures a 500 response is sent to the client rather than
 	// sending no response at all.
-	router.Use(gin.Recovery())
+	router.Use(Recovery())
 
 	if debugMode {
 		// Logger middleware outputs very detailed logging of webserver requests


### PR DESCRIPTION
This has several advantages over the middleware provided by gin:

- It will log to the log file and not just stdout. (Closes #246)
- It will log the whole HTTP request which caused the panic (headers and body).
- Log message doesnt include any ANSI color codes, so log file is tidier.

The code to format the stack trace is mostly inherited from the gin recovery.go