### PR TITLE
Remove relayFee todo.

### DIFF
--- a/webapi/getfeeaddress.go
+++ b/webapi/getfeeaddress.go
@@ -49,7 +49,7 @@ func getCurrentFee(dcrdClient *rpc.DcrdRPC) (dcrutil.Amount, error) {
 	if err != nil {
 		return 0, err
 	}
-	relayFee, err := dcrutil.NewAmount(relayFee)
+	relayFee, err := dcrutil.NewAmount(0.0001)
 	if err != nil {
 		return 0, err
 	}

--- a/webapi/webapi.go
+++ b/webapi/webapi.go
@@ -38,8 +38,6 @@ type Config struct {
 }
 
 const (
-	// TODO: Make this configurable or get it from RPC.
-	relayFee = 0.0001
 	// requiredConfs is the number of confirmations required to consider a
 	// ticket purchase or a fee transaction to be final.
 	requiredConfs = 6


### PR DESCRIPTION
Accepting this as a hard-coded value. It will not be retrieved from RPC or config.

Closes #54 