### PR TITLE
Update to golangci-lint 1.40.1.

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Check out source
         uses: actions/checkout@v2
       - name: Install Linters
-        run: "curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.38.0"
+        run: "curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.40.1"
       - name: Build
         env:
           GO111MODULE: "on"

--- a/database/ticket.go
+++ b/database/ticket.go
@@ -6,7 +6,6 @@ package database
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"time"
 
@@ -17,15 +16,15 @@ import (
 type FeeStatus string
 
 const (
-	// No fee transaction has been received yet.
+	// NoFee indicates no fee tx has been received yet.
 	NoFee FeeStatus = "none"
-	// Fee transaction has been received but not broadcast.
+	// FeeReceieved indicates fee tx has been received but not broadcast.
 	FeeReceieved FeeStatus = "received"
-	// Fee transaction has been broadcast but not confirmed.
+	// FeeBroadcast indicates fee tx has been broadcast but not confirmed.
 	FeeBroadcast FeeStatus = "broadcast"
-	// Fee transaction has been broadcast and confirmed.
+	// FeeConfirmed indicates fee tx has been broadcast and confirmed.
 	FeeConfirmed FeeStatus = "confirmed"
-	// Fee transaction could not be broadcast due to an error.
+	// FeeError indicates fee tx could not be broadcast due to an error.
 	FeeError FeeStatus = "error"
 )
 
@@ -33,9 +32,10 @@ const (
 type TicketOutcome string
 
 const (
-	// Ticket has been revoked, either because it was missed or it expired.
+	// Revoked indicates the ticket has been revoked, either because it was
+	// missed or it expired.
 	Revoked TicketOutcome = "revoked"
-	// Ticket has already voted.
+	// Voted indicates the ticket has already voted.
 	Voted TicketOutcome = "voted"
 )
 
@@ -76,10 +76,6 @@ func (t *Ticket) FeeExpired() bool {
 	now := time.Now()
 	return now.After(time.Unix(t.FeeExpiration, 0))
 }
-
-var (
-	ErrNoTicketFound = errors.New("no ticket found")
-)
 
 // InsertNewTicket will insert the provided ticket into the database. Returns an
 // error if either the ticket hash or fee address already exist.

--- a/database/ticket_test.go
+++ b/database/ticket_test.go
@@ -11,7 +11,7 @@ import (
 	"time"
 )
 
-var seededRand *rand.Rand = rand.New(rand.NewSource(time.Now().UnixNano()))
+var seededRand = rand.New(rand.NewSource(time.Now().UnixNano()))
 
 // randString randomly generates a string of the requested length, using only
 // characters from the provided charset.

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -36,7 +36,7 @@ fi
 golangci-lint run --disable-all --deadline=10m \
   --out-format=$OUT_FORMAT \
   --enable=gofmt \
-  --enable=golint \
+  --enable=revive \
   --enable=govet \
   --enable=gosimple \
   --enable=unconvert \


### PR DESCRIPTION
Linter `golint` has been deprecated and replaced with `revive`.