### PR TITLE
Add network proportion to homepage and /vspinfo (and revoked proportion)

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -55,7 +55,7 @@ when a VSP is closed will result in an error.
         "voted":25,
         "revoked":3,
         "blockheight":623212,
-        "networkproportion":0.04847841472045294
+        "estimatednetworkproportion":0.048478414
     }
     ```
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -54,7 +54,8 @@ when a VSP is closed will result in an error.
         "voting":10,
         "voted":25,
         "revoked":3,
-        "blockheight":623212
+        "blockheight":623212,
+        "networkproportion":0.04847841472045294
     }
     ```
 

--- a/rpc/dcrd.go
+++ b/rpc/dcrd.go
@@ -224,17 +224,6 @@ func (c *DcrdRPC) CanTicketVote(rawTx *dcrdtypes.TxRawResult, ticketHash string,
 	return live, nil
 }
 
-// GetBestBlockHeight uses getblockcount RPC to query the height of the best
-// block known by the dcrd instance.
-func (c *DcrdRPC) GetBestBlockHeight() (int64, error) {
-	var height int64
-	err := c.Call(c.ctx, "getblockcount", &height)
-	if err != nil {
-		return 0, err
-	}
-	return height, nil
-}
-
 // ParseBlockConnectedNotification extracts the block header from a
 // blockconnected JSON-RPC notification.
 func ParseBlockConnectedNotification(params json.RawMessage) (*wire.BlockHeader, error) {

--- a/webapi/formatting.go
+++ b/webapi/formatting.go
@@ -54,6 +54,6 @@ func atomsToDCR(atoms int64) string {
 	return dcrutil.Amount(atoms).String()
 }
 
-func floatToPercent(input float64) string {
+func float32ToPercent(input float32) string {
 	return fmt.Sprintf("%.2f%%", input*100)
 }

--- a/webapi/formatting.go
+++ b/webapi/formatting.go
@@ -53,3 +53,7 @@ func indentJSON(input string) template.HTML {
 func atomsToDCR(atoms int64) string {
 	return dcrutil.Amount(atoms).String()
 }
+
+func floatToPercent(input float64) string {
+	return fmt.Sprintf("%.2f%%", input*100)
+}

--- a/webapi/homepage.go
+++ b/webapi/homepage.go
@@ -33,7 +33,7 @@ type vspStats struct {
 	Debug             bool
 	Designation       string
 	BlockHeight       uint32
-	NetworkProportion float64
+	NetworkProportion float32
 }
 
 var statsMtx sync.RWMutex
@@ -94,7 +94,7 @@ func updateVSPStats(ctx context.Context, db *database.VspDatabase,
 	stats.Voted = voted
 	stats.Revoked = revoked
 	stats.BlockHeight = bestBlock.Height
-	stats.NetworkProportion = float64(voting) / float64(bestBlock.PoolSize)
+	stats.NetworkProportion = float32(voting) / float32(bestBlock.PoolSize)
 
 	return nil
 }

--- a/webapi/homepage.go
+++ b/webapi/homepage.go
@@ -21,18 +21,19 @@ import (
 // vspStats is used to cache values which are commonly used by the API, so
 // repeated web requests don't repeatedly trigger DB or RPC calls.
 type vspStats struct {
-	PubKey       string
-	Voting       int64
-	Voted        int64
-	Revoked      int64
-	VSPFee       float64
-	Network      string
-	UpdateTime   string
-	SupportEmail string
-	VspClosed    bool
-	Debug        bool
-	Designation  string
-	BlockHeight  int64
+	PubKey            string
+	Voting            int64
+	Voted             int64
+	Revoked           int64
+	VSPFee            float64
+	Network           string
+	UpdateTime        string
+	SupportEmail      string
+	VspClosed         bool
+	Debug             bool
+	Designation       string
+	BlockHeight       uint32
+	NetworkProportion float64
 }
 
 var statsMtx sync.RWMutex
@@ -80,7 +81,7 @@ func updateVSPStats(ctx context.Context, db *database.VspDatabase,
 		return err
 	}
 
-	blockHeight, err := dcrdClient.GetBestBlockHeight()
+	bestBlock, err := dcrdClient.GetBestBlockHeader()
 	if err != nil {
 		return err
 	}
@@ -92,7 +93,8 @@ func updateVSPStats(ctx context.Context, db *database.VspDatabase,
 	stats.Voting = voting
 	stats.Voted = voted
 	stats.Revoked = revoked
-	stats.BlockHeight = blockHeight
+	stats.BlockHeight = bestBlock.Height
+	stats.NetworkProportion = float64(voting) / float64(bestBlock.PoolSize)
 
 	return nil
 }

--- a/webapi/homepage.go
+++ b/webapi/homepage.go
@@ -34,6 +34,7 @@ type vspStats struct {
 	Designation       string
 	BlockHeight       uint32
 	NetworkProportion float32
+	RevokedProportion float32
 }
 
 var statsMtx sync.RWMutex
@@ -95,6 +96,7 @@ func updateVSPStats(ctx context.Context, db *database.VspDatabase,
 	stats.Revoked = revoked
 	stats.BlockHeight = bestBlock.Height
 	stats.NetworkProportion = float32(voting) / float32(bestBlock.PoolSize)
+	stats.RevokedProportion = float32(revoked) / float32(voted)
 
 	return nil
 }

--- a/webapi/public/css/vspd.css
+++ b/webapi/public/css/vspd.css
@@ -53,6 +53,11 @@ body {
     color: #091440;
 }
 
+.vsp-stats .stat-value .text-muted{
+    font-size: 18px;
+    color: #8997A5;
+}
+
 footer {
     flex-shrink: 0;
     font-size: 0.8rem;

--- a/webapi/templates/vsp-stats.html
+++ b/webapi/templates/vsp-stats.html
@@ -27,6 +27,11 @@
         <div class="stat-value">{{ .Network }}</div>
     </div>
 
+    <div class="col-6 col-sm-4 col-lg-2 py-3">
+        <div class="stat-title">Network Proportion</div>
+        <div class="stat-value">{{ floatToPercent .NetworkProportion }}</div>
+    </div>
+
 </div>
 
 {{ end }}

--- a/webapi/templates/vsp-stats.html
+++ b/webapi/templates/vsp-stats.html
@@ -29,7 +29,7 @@
 
     <div class="col-6 col-sm-4 col-lg-2 py-3">
         <div class="stat-title">Network Proportion</div>
-        <div class="stat-value">{{ floatToPercent .NetworkProportion }}</div>
+        <div class="stat-value">{{ float32ToPercent .NetworkProportion }}</div>
     </div>
 
 </div>

--- a/webapi/templates/vsp-stats.html
+++ b/webapi/templates/vsp-stats.html
@@ -14,7 +14,10 @@
 
     <div class="col-6 col-sm-4 col-lg-2 py-3">
         <div class="stat-title">Revoked tickets</div>
-        <div class="stat-value">{{ .Revoked }}</div>
+        <div class="stat-value">
+            {{ .Revoked }}
+            <span class="text-muted">({{ float32ToPercent .RevokedProportion }})</span>
+        </div>
     </div>
 
     <div class="col-6 col-sm-4 col-lg-2 py-3">

--- a/webapi/types.go
+++ b/webapi/types.go
@@ -5,17 +5,18 @@
 package webapi
 
 type vspInfoResponse struct {
-	APIVersions   []int64 `json:"apiversions"`
-	Timestamp     int64   `json:"timestamp"`
-	PubKey        []byte  `json:"pubkey"`
-	FeePercentage float64 `json:"feepercentage"`
-	VspClosed     bool    `json:"vspclosed"`
-	Network       string  `json:"network"`
-	VspdVersion   string  `json:"vspdversion"`
-	Voting        int64   `json:"voting"`
-	Voted         int64   `json:"voted"`
-	Revoked       int64   `json:"revoked"`
-	BlockHeight   int64   `json:"blockheight"`
+	APIVersions       []int64 `json:"apiversions"`
+	Timestamp         int64   `json:"timestamp"`
+	PubKey            []byte  `json:"pubkey"`
+	FeePercentage     float64 `json:"feepercentage"`
+	VspClosed         bool    `json:"vspclosed"`
+	Network           string  `json:"network"`
+	VspdVersion       string  `json:"vspdversion"`
+	Voting            int64   `json:"voting"`
+	Voted             int64   `json:"voted"`
+	Revoked           int64   `json:"revoked"`
+	BlockHeight       uint32  `json:"blockheight"`
+	NetworkProportion float64 `json:"networkproportion"`
 }
 
 type feeAddressRequest struct {

--- a/webapi/types.go
+++ b/webapi/types.go
@@ -16,7 +16,7 @@ type vspInfoResponse struct {
 	Voted             int64   `json:"voted"`
 	Revoked           int64   `json:"revoked"`
 	BlockHeight       uint32  `json:"blockheight"`
-	NetworkProportion float64 `json:"networkproportion"`
+	NetworkProportion float32 `json:"estimatednetworkproportion"`
 }
 
 type feeAddressRequest struct {

--- a/webapi/vspinfo.go
+++ b/webapi/vspinfo.go
@@ -15,16 +15,17 @@ import (
 func vspInfo(c *gin.Context) {
 	cachedStats := getVSPStats()
 	sendJSONResponse(vspInfoResponse{
-		APIVersions:   []int64{3},
-		Timestamp:     time.Now().Unix(),
-		PubKey:        signPubKey,
-		FeePercentage: cfg.VSPFee,
-		Network:       cfg.NetParams.Name,
-		VspClosed:     cfg.VspClosed,
-		VspdVersion:   version.String(),
-		Voting:        cachedStats.Voting,
-		Voted:         cachedStats.Voted,
-		Revoked:       cachedStats.Revoked,
-		BlockHeight:   cachedStats.BlockHeight,
+		APIVersions:       []int64{3},
+		Timestamp:         time.Now().Unix(),
+		PubKey:            signPubKey,
+		FeePercentage:     cfg.VSPFee,
+		Network:           cfg.NetParams.Name,
+		VspClosed:         cfg.VspClosed,
+		VspdVersion:       version.String(),
+		Voting:            cachedStats.Voting,
+		Voted:             cachedStats.Voted,
+		Revoked:           cachedStats.Revoked,
+		BlockHeight:       cachedStats.BlockHeight,
+		NetworkProportion: cachedStats.NetworkProportion,
 	}, c)
 }

--- a/webapi/webapi.go
+++ b/webapi/webapi.go
@@ -177,14 +177,14 @@ func router(debugMode bool, cookieSecret []byte, dcrd rpc.DcrdConnect, wallets r
 
 	// Add custom functions for use in templates.
 	router.SetFuncMap(template.FuncMap{
-		"txURL":          txURL(cfg.BlockExplorerURL),
-		"addressURL":     addressURL(cfg.BlockExplorerURL),
-		"blockURL":       blockURL(cfg.BlockExplorerURL),
-		"dateTime":       dateTime,
-		"stripWss":       stripWss,
-		"indentJSON":     indentJSON,
-		"atomsToDCR":     atomsToDCR,
-		"floatToPercent": floatToPercent,
+		"txURL":            txURL(cfg.BlockExplorerURL),
+		"addressURL":       addressURL(cfg.BlockExplorerURL),
+		"blockURL":         blockURL(cfg.BlockExplorerURL),
+		"dateTime":         dateTime,
+		"stripWss":         stripWss,
+		"indentJSON":       indentJSON,
+		"atomsToDCR":       atomsToDCR,
+		"float32ToPercent": float32ToPercent,
 	})
 
 	router.LoadHTMLGlob("webapi/templates/*.html")

--- a/webapi/webapi.go
+++ b/webapi/webapi.go
@@ -177,13 +177,14 @@ func router(debugMode bool, cookieSecret []byte, dcrd rpc.DcrdConnect, wallets r
 
 	// Add custom functions for use in templates.
 	router.SetFuncMap(template.FuncMap{
-		"txURL":      txURL(cfg.BlockExplorerURL),
-		"addressURL": addressURL(cfg.BlockExplorerURL),
-		"blockURL":   blockURL(cfg.BlockExplorerURL),
-		"dateTime":   dateTime,
-		"stripWss":   stripWss,
-		"indentJSON": indentJSON,
-		"atomsToDCR": atomsToDCR,
+		"txURL":          txURL(cfg.BlockExplorerURL),
+		"addressURL":     addressURL(cfg.BlockExplorerURL),
+		"blockURL":       blockURL(cfg.BlockExplorerURL),
+		"dateTime":       dateTime,
+		"stripWss":       stripWss,
+		"indentJSON":     indentJSON,
+		"atomsToDCR":     atomsToDCR,
+		"floatToPercent": floatToPercent,
 	})
 
 	router.LoadHTMLGlob("webapi/templates/*.html")


### PR DESCRIPTION
Proportion is calculated using the number of tickets  currently registered with the VSP, divided by the total size of the network ticket pool as reported by `getblockheader`.

The value will only ever be an estimate because:

- it's possible for a single ticket to be added to multiple VSPs.
- vspd does not distinguish between immature and live tickets, whereas `getblockheader` only reports live tickets.
- `getblockheader` is reporting the size of the ticket pool as of the previous block, not the current block.

Closes #206