### PR TITLE
Improve performance of filtering DB tickets.

### DIFF
--- a/database/database.go
+++ b/database/database.go
@@ -105,6 +105,18 @@ func bytesToUint32(bytes []byte) uint32 {
 	return binary.LittleEndian.Uint32(bytes)
 }
 
+func bytesToBool(bytes []byte) bool {
+	return bytes[0] == 1
+}
+
+func boolToBytes(b bool) []byte {
+	if b {
+		return []byte{1}
+	}
+
+	return []byte{0}
+}
+
 // CreateNew intializes a new bbolt database with all of the necessary vspd
 // buckets, and inserts:
 // - the provided extended pubkey (to be used for deriving fee addresses).

--- a/database/ticket_test.go
+++ b/database/ticket_test.go
@@ -238,7 +238,7 @@ func testFilterTickets(t *testing.T) {
 
 	// Only one ticket should be confirmed.
 	retrieved, err = db.filterTickets(func(t *bolt.Bucket) bool {
-		return t.Get(confirmedK)[0] == byte(1)
+		return bytesToBool(t.Get(confirmedK))
 	})
 	if err != nil {
 		t.Fatalf("error filtering tickets: %v", err)


### PR DESCRIPTION
Previously all tickets were fully deserialized before applying the filter - now only the required fields are deserialized. The full ticket is only deserialized if the filter matches.

On a database with 150k tickets, time to execute a filter with a 10% hit rate  is reduced by approx two thirds (950ms vs 310ms)