### PR TITLE
Add vspclosedmsg config.

### DIFF
--- a/config.go
+++ b/config.go
@@ -62,6 +62,7 @@ type config struct {
 	SupportEmail    string        `long:"supportemail" ini-name:"supportemail" description:"Email address for users in need of support."`
 	BackupInterval  time.Duration `long:"backupinterval" ini-name:"backupinterval" description:"Time period between automatic database backups. Valid time units are {s,m,h}. Minimum 30 seconds."`
 	VspClosed       bool          `long:"vspclosed" ini-name:"vspclosed" description:"Closed prevents the VSP from accepting new tickets."`
+	VspClosedMsg    string        `long:"vspclosedmsg" ini-name:"vspclosedmsg" description:"A short message displayed on the webpage and returned by the status API endpoint if vspdclosed is true."`
 	AdminPass       string        `long:"adminpass" ini-name:"adminpass" description:"Password for accessing admin page."`
 	Designation     string        `long:"designation" ini-name:"designation" description:"Short name for the VSP. Customizes the logo in the top toolbar."`
 
@@ -292,6 +293,11 @@ func loadConfig() (*config, error) {
 		return nil, errors.New("invalid vspfee - should be greater than 0.01 and less than 100.0")
 	}
 
+	// If VSP is not closed, ignore any provided closure message.
+	if !cfg.VspClosed {
+		cfg.VspClosedMsg = ""
+	}
+
 	// Ensure the support email address is set.
 	if cfg.SupportEmail == "" {
 		return nil, errors.New("the supportemail option is not set")
@@ -409,7 +415,7 @@ func loadConfig() (*config, error) {
 		// If database already exists, return error.
 		if fileExists(cfg.dbPath) {
 			return nil, fmt.Errorf("database already initialized at %s, "+
-				"--feexpub option is not needed.", cfg.dbPath)
+				"--feexpub option is not needed", cfg.dbPath)
 		}
 
 		// Ensure provided value is a valid key for the selected network.
@@ -431,7 +437,7 @@ func loadConfig() (*config, error) {
 		// If database does not exist, return error.
 		if !fileExists(cfg.dbPath) {
 			return nil, fmt.Errorf("no database exists in %s. Run vspd with the"+
-				" --feexpub option to initialize one.", dataDir)
+				" --feexpub option to initialize one", dataDir)
 		}
 	}
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -49,6 +49,7 @@ when a VSP is closed will result in an error.
         "pubkey":"SjAmrAqH7LScCUwM1qo5O6Cu7aKhrM1ORszgZwD7HmU=",
         "feepercentage":3.0,
         "vspclosed":false,
+        "vspclosedmsg": "",
         "network":"testnet3",
         "vspdversion":"1.0.0-pre",
         "voting":10,

--- a/harness.sh
+++ b/harness.sh
@@ -151,6 +151,7 @@ webserverdebug = false
 supportemail = example@test.com
 backupinterval = 3m0s
 vspclosed = false
+vspclosedmsg = Your tickets are no longer welcome here. Please go away.
 adminpass=12345
 designation = harness
 EOF

--- a/vspd.go
+++ b/vspd.go
@@ -90,6 +90,7 @@ func run(ctx context.Context) error {
 		BlockExplorerURL:     cfg.netParams.BlockExplorerURL,
 		SupportEmail:         cfg.SupportEmail,
 		VspClosed:            cfg.VspClosed,
+		VspClosedMsg:         cfg.VspClosedMsg,
 		AdminPass:            cfg.AdminPass,
 		Debug:                cfg.WebServerDebug,
 		Designation:          cfg.Designation,

--- a/webapi/homepage.go
+++ b/webapi/homepage.go
@@ -30,6 +30,7 @@ type vspStats struct {
 	UpdateTime        string
 	SupportEmail      string
 	VspClosed         bool
+	VspClosedMsg      string
 	Debug             bool
 	Designation       string
 	BlockHeight       uint32
@@ -60,6 +61,7 @@ func initVSPStats() {
 		Network:      cfg.NetParams.Name,
 		SupportEmail: cfg.SupportEmail,
 		VspClosed:    cfg.VspClosed,
+		VspClosedMsg: cfg.VspClosedMsg,
 		Debug:        cfg.Debug,
 		Designation:  cfg.Designation,
 	}

--- a/webapi/templates/homepage.html
+++ b/webapi/templates/homepage.html
@@ -5,9 +5,16 @@
 
         {{ if .VspStats.VspClosed }}
             <div class="alert alert-danger">
-                <h4 class="alert-heading">This Voting Service Provider is closed</h4>
-                A closed VSP will still vote on tickets with already paid fees, but will not accept new any tickets.
-                Visit <a href="https://decred.org/vsp/" class="alert-link" target="_blank" rel="noopener noreferrer">decred.org</a> to find a new VSP.
+                <h4 class="alert-heading mb-3">
+                    This Voting Service Provider is closed
+                </h4>
+                <p>
+                    {{ .VspStats.VspClosedMsg }}
+                </p>
+                <p>
+                    A closed VSP will still vote on tickets with already paid fees, but will not accept new any tickets.
+                    Visit <a href="https://decred.org/vsp/" class="alert-link" target="_blank" rel="noopener noreferrer">decred.org</a> to find a new VSP.
+                </p>
             </div>
         {{ end }}
 

--- a/webapi/types.go
+++ b/webapi/types.go
@@ -10,6 +10,7 @@ type vspInfoResponse struct {
 	PubKey            []byte  `json:"pubkey"`
 	FeePercentage     float64 `json:"feepercentage"`
 	VspClosed         bool    `json:"vspclosed"`
+	VspClosedMsg      string  `json:"vspclosedmsg"`
 	Network           string  `json:"network"`
 	VspdVersion       string  `json:"vspdversion"`
 	Voting            int64   `json:"voting"`

--- a/webapi/vspinfo.go
+++ b/webapi/vspinfo.go
@@ -21,6 +21,7 @@ func vspInfo(c *gin.Context) {
 		FeePercentage:     cfg.VSPFee,
 		Network:           cfg.NetParams.Name,
 		VspClosed:         cfg.VspClosed,
+		VspClosedMsg:      cfg.VspClosedMsg,
 		VspdVersion:       version.String(),
 		Voting:            cachedStats.Voting,
 		Voted:             cachedStats.Voted,

--- a/webapi/webapi.go
+++ b/webapi/webapi.go
@@ -31,6 +31,7 @@ type Config struct {
 	FeeAccountName       string
 	SupportEmail         string
 	VspClosed            bool
+	VspClosedMsg         string
 	AdminPass            string
 	Debug                bool
 	Designation          string


### PR DESCRIPTION
If vspclosed is set to true, the provided message will be displayed on the webpage and returned by the status API endpoint.

Suggested by @xaur in #232 