### PR TITLE
Add shutdownWg to dcrd notif handler.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ VSP will add the ticket to a pool of always-online voting wallets.
 
 ## Implementation
 
-vspd is built and tested on go 1.14 and 1.15, making use of the following
+vspd is built and tested on go 1.15 and 1.16, making use of the following
 libraries:
 
 - [gin-gonic/gin](https://github.com/gin-gonic/gin) webserver.

--- a/background/background.go
+++ b/background/background.go
@@ -26,7 +26,9 @@ var (
 	notifierClosed chan struct{}
 )
 
-type NotificationHandler struct{}
+type NotificationHandler struct {
+	ShutdownWg *sync.WaitGroup
+}
 
 const (
 	// consistencyInterval is the time period between wallet consistency checks.
@@ -41,6 +43,9 @@ const (
 // because that will cause the client to close and no further notifications will
 // be received until a new connection is established.
 func (n *NotificationHandler) Notify(method string, params json.RawMessage) error {
+	n.ShutdownWg.Add(1)
+	defer n.ShutdownWg.Done()
+
 	if method != "blockconnected" {
 		return nil
 	}

--- a/vspd.go
+++ b/vspd.go
@@ -105,8 +105,9 @@ func run(ctx context.Context) error {
 	}
 
 	// Create a dcrd client with a blockconnected notification handler.
+	notifHandler := background.NotificationHandler{ShutdownWg: &shutdownWg}
 	dcrdWithNotifs := rpc.SetupDcrd(cfg.DcrdUser, cfg.DcrdPass,
-		cfg.DcrdHost, cfg.dcrdCert, &background.NotificationHandler{})
+		cfg.DcrdHost, cfg.dcrdCert, &notifHandler)
 	defer dcrdWithNotifs.Close()
 
 	// Start background process which will continually attempt to reconnect to


### PR DESCRIPTION
This prevents db/dcrd/dcrwallet connections from being closed while the dcrd notification handler is still running.

Marking this as a draft because I want to run it for a while before merging it.