### PR TITLE
Admin tabs for Database and Logout

### DIFF
--- a/database/ticket.go
+++ b/database/ticket.go
@@ -271,6 +271,17 @@ func (vdb *VspDatabase) GetTicketByHash(ticketHash string) (Ticket, bool, error)
 	return ticket, found, err
 }
 
+// Size returns the current size of the database in bytes. Note that this may
+// not exactly match the size of the database file stored on disk.
+func (vdb *VspDatabase) Size() (uint64, error) {
+	var size uint64
+	err := vdb.db.View(func(tx *bolt.Tx) error {
+		size = uint64(tx.Size())
+		return nil
+	})
+	return size, err
+}
+
 // CountTickets returns the total number of voted, revoked, and currently voting
 // tickets. This func iterates over every ticket so should be used sparingly.
 func (vdb *VspDatabase) CountTickets() (int64, int64, int64, error) {

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/decred/dcrd/txscript/v4 v4.0.0-20210415225937-dd2a786ee1d1
 	github.com/decred/dcrd/wire v1.4.0
 	github.com/decred/slog v1.2.0
+	github.com/dustin/go-humanize v1.0.0
 	github.com/gin-gonic/gin v1.7.1
 	github.com/gorilla/sessions v1.2.1
 	github.com/jessevdk/go-flags v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -74,6 +74,8 @@ github.com/decred/go-socks v1.1.0/go.mod h1:sDhHqkZH0X4JjSa02oYOGhcGHYp12FsY1jQ/
 github.com/decred/slog v1.1.0/go.mod h1:kVXlGnt6DHy2fV5OjSeuvCJ0OmlmTF6LFpEPMu/fOY0=
 github.com/decred/slog v1.2.0 h1:soHAxV52B54Di3WtKLfPum9OFfWqwtf/ygf9njdfnPM=
 github.com/decred/slog v1.2.0/go.mod h1:kVXlGnt6DHy2fV5OjSeuvCJ0OmlmTF6LFpEPMu/fOY0=
+github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
+github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=

--- a/webapi/cache.go
+++ b/webapi/cache.go
@@ -80,7 +80,18 @@ func updateCache(ctx context.Context, db *database.VspDatabase,
 	cache.Revoked = revoked
 	cache.BlockHeight = bestBlock.Height
 	cache.NetworkProportion = float32(voting) / float32(bestBlock.PoolSize)
-	cache.RevokedProportion = float32(revoked) / float32(voted)
+
+	// Prevent dividing by zero when pool has no voted tickets.
+	switch voted {
+	case 0:
+		if revoked == 0 {
+			cache.RevokedProportion = 0
+		} else {
+			cache.RevokedProportion = 1
+		}
+	default:
+		cache.RevokedProportion = float32(revoked) / float32(voted)
+	}
 
 	return nil
 }

--- a/webapi/cache.go
+++ b/webapi/cache.go
@@ -13,6 +13,7 @@ import (
 	"github.com/decred/dcrd/chaincfg/v3"
 	"github.com/decred/vspd/database"
 	"github.com/decred/vspd/rpc"
+	"github.com/dustin/go-humanize"
 )
 
 // apiCache is used to cache values which are commonly used by the API, so
@@ -20,6 +21,7 @@ import (
 type apiCache struct {
 	UpdateTime        string
 	PubKey            string
+	DatabaseSize      string
 	Voting            int64
 	Voted             int64
 	Revoked           int64
@@ -54,6 +56,11 @@ func initCache() {
 func updateCache(ctx context.Context, db *database.VspDatabase,
 	dcrd rpc.DcrdConnect, netParams *chaincfg.Params) error {
 
+	dbSize, err := db.Size()
+	if err != nil {
+		return err
+	}
+
 	// Get latest counts of voting, voted and revoked tickets.
 	voting, voted, revoked, err := db.CountTickets()
 	if err != nil {
@@ -75,6 +82,7 @@ func updateCache(ctx context.Context, db *database.VspDatabase,
 	defer cacheMtx.Unlock()
 
 	cache.UpdateTime = dateTime(time.Now().Unix())
+	cache.DatabaseSize = humanize.Bytes(dbSize)
 	cache.Voting = voting
 	cache.Voted = voted
 	cache.Revoked = revoked

--- a/webapi/public/css/vspd.css
+++ b/webapi/public/css/vspd.css
@@ -96,11 +96,6 @@ footer .code {
     border-color: transparent;
 }
 
-.btn-small {
-    padding: 6px 10px;
-    font-size: 13px;
-}
-
 .block__content h1 {
     color: #091440;
     font-size: 24px;
@@ -196,7 +191,7 @@ footer .code {
     list-style:none;
     display:flex;
     padding: 0;
-    margin: 0 0 30px;
+    margin: 0 0 25px;
 }
 
 .tabset > ul label {
@@ -239,7 +234,7 @@ footer .code {
     left:-999em;
 }
 .tabset > div > section {
-    padding: 0;
+    padding: 0 10px 10px 10px;
 }
 
 .tabset > input:nth-child(1):checked ~ div > section:nth-child(1),

--- a/webapi/public/css/vspd.css
+++ b/webapi/public/css/vspd.css
@@ -58,6 +58,10 @@ body {
     color: #8997A5;
 }
 
+.orange {
+    color: #ed6d47;
+}
+
 footer {
     flex-shrink: 0;
     font-size: 0.8rem;

--- a/webapi/templates/admin.html
+++ b/webapi/templates/admin.html
@@ -4,18 +4,9 @@
     <div class="container">
 
         <div class="d-flex flex-wrap">
-            <h1 class="mr-auto text-nowrap">Admin Panel</h1>
-            
-            <div class="row">
-                <a class="m-2 btn btn-primary btn-small" href="/admin/backup" download>Backup</a>
-                
-                <form class="p-2" action="/admin/logout" method="post">
-                    <button type="submit" class="btn btn-primary btn-small">Logout</button>
-                </form>
-            </div>
+            <h1>Admin Panel</h1>
         </div>
         
-
         {{ template "vsp-stats" . }}
 
     </div>
@@ -33,7 +24,6 @@
                         name="tabset_1"
                         id="tabset_1_1"
                         hidden
-                        aria-hidden="true"
                         {{ with .SearchResult }}{{ else }}checked{{ end }}
                     >
                     <input
@@ -41,12 +31,25 @@
                         name="tabset_1"
                         id="tabset_1_2"
                         hidden
-                        aria-hidden="true"
                         {{ with .SearchResult }}checked{{ end }}
+                    >
+                    <input
+                        type="radio"
+                        name="tabset_1"
+                        id="tabset_1_3"
+                        hidden
+                    >
+                    <input
+                        type="radio"
+                        name="tabset_1"
+                        id="tabset_1_4"
+                        hidden
                     >
                     <ul>
                         <li><label for="tabset_1_1">Wallet Status</label></li>
                         <li><label for="tabset_1_2">Ticket Search</label></li>
+                        <li><label for="tabset_1_3">Database</label></li>
+                        <li><label for="tabset_1_4">Logout</label></li>
                     </ul>
                     
                     <div>
@@ -274,6 +277,17 @@
                                     <p>No ticket found with hash <span class="code">{{ .Hash }}</span></p>
                                 {{ end }}
                             {{ end }}
+                        </section>
+
+                        <section>
+                            <p>Database size: {{ .WebApiCache.DatabaseSize }}</p>
+                            <a class="btn btn-primary" href="/admin/backup" download>Download Backup</a>
+                        </section>
+
+                        <section>
+                            <form action="/admin/logout" method="post">
+                                <button type="submit" class="btn btn-primary">Logout</button>
+                            </form>
                         </section>
 
                     </div>

--- a/webapi/templates/admin.html
+++ b/webapi/templates/admin.html
@@ -136,7 +136,7 @@
                                 {{ with .SearchResult }}
                                 value="{{ .Ticket.Hash }}"
                                 {{ end }}>
-                                <button class="ml-3 btn btn-primary" type="submit">Search</button>
+                                <button class="btn btn-primary d-block my-2" type="submit">Search</button>
                             </form>
             
                             {{ with .SearchResult }}

--- a/webapi/templates/login.html
+++ b/webapi/templates/login.html
@@ -2,14 +2,15 @@
 
 <div class="py-4 container">
     <h1>Login</h1>
-    <form action="/admin" method="post">
+    <form class="py-3" action="/admin" method="post">
+
         <input type="password" name="password" required placeholder="Enter password">
-        <button class="ml-3 btn btn-primary" type="submit">Login</button>
+        
+        <p class="my-1 orange" style="visibility:{{ if .IncorrectPassword }}visible{{ else }}hidden{{ end }};">Incorrect password</p>
+
+        <button class="btn btn-primary" type="submit">Login</button>
     </form>
 
-    {{ if .IncorrectPassword }}
-        <p>Incorrect password</p>
-    {{ end }}
 </div>
 
 {{ template "footer" . }}

--- a/webapi/templates/vsp-stats.html
+++ b/webapi/templates/vsp-stats.html
@@ -4,18 +4,18 @@
     
     <div class="col-6 col-sm-4 col-lg-2 py-3">
         <div class="stat-title">Live tickets</div>
-        <div class="stat-value">{{ .WebApiCache.Voting }}</div>
+        <div class="stat-value">{{ comma .WebApiCache.Voting }}</div>
     </div>
 
     <div class="col-6 col-sm-4 col-lg-2 py-3">
         <div class="stat-title">Voted tickets</div>
-        <div class="stat-value">{{ .WebApiCache.Voted }}</div>
+        <div class="stat-value">{{ comma .WebApiCache.Voted }}</div>
     </div>
 
     <div class="col-6 col-sm-4 col-lg-2 py-3">
         <div class="stat-title">Revoked tickets</div>
         <div class="stat-value">
-            {{ .WebApiCache.Revoked }}
+            {{ comma .WebApiCache.Revoked }}
             <span class="text-muted">({{ float32ToPercent .WebApiCache.RevokedProportion }})</span>
         </div>
     </div>

--- a/webapi/webapi.go
+++ b/webapi/webapi.go
@@ -20,6 +20,7 @@ import (
 	"github.com/decred/dcrd/chaincfg/v3"
 	"github.com/decred/vspd/database"
 	"github.com/decred/vspd/rpc"
+	"github.com/dustin/go-humanize"
 	"github.com/gin-gonic/gin"
 	"github.com/gorilla/sessions"
 )
@@ -187,6 +188,7 @@ func router(debugMode bool, cookieSecret []byte, dcrd rpc.DcrdConnect, wallets r
 		"indentJSON":       indentJSON,
 		"atomsToDCR":       atomsToDCR,
 		"float32ToPercent": float32ToPercent,
+		"comma":            humanize.Comma,
 	})
 
 	router.LoadHTMLGlob("webapi/templates/*.html")


### PR DESCRIPTION
- Adds database and logout tabs to admin page. Existing buttons to logout and download DB backup are moved into the new tabs. Also the database size is displayed in the database tab.

- Comma separate large numbers in the UI, eg. `121,213` instead of `121213`

- Fix a bug where `NaN` was displayed when the VSP has zero voted tickets. This was due to dividing by zero.

- Put search/login buttons under their respective hash/password input elements. This improves display on narrow displays such as mobile.

- Show incorrect password prompt in orange, matching other Decred UIs.

Running on https://testnet-vsp.jholdstock.uk/