### PR TITLE
Be more specific about consensus vote choices.

### DIFF
--- a/background/background.go
+++ b/background/background.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Decred developers
+// Copyright (c) 2020-2021 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -212,7 +212,7 @@ func blockConnected() {
 					continue
 				}
 
-				// Set vote choices on voting wallets.
+				// Set consensus vote choices on voting wallets.
 				for agenda, choice := range ticket.VoteChoices {
 					err = walletClient.SetVoteChoice(agenda, choice, ticket.Hash)
 					if err != nil {
@@ -513,7 +513,7 @@ func checkWalletConsistency() {
 				continue
 			}
 
-			// Check if vote choices match
+			// Check if consensus vote choices match
 			for dbAgenda, dbChoice := range dbTicket.VoteChoices {
 				match := false
 				for _, walletChoice := range walletTicket.Choices {
@@ -527,7 +527,7 @@ func checkWalletConsistency() {
 					continue
 				}
 
-				log.Debugf("%s: Updating incorrect vote choices (wallet=%s, agenda=%s, ticketHash=%s)",
+				log.Debugf("%s: Updating incorrect consensus vote choices (wallet=%s, agenda=%s, ticketHash=%s)",
 					funcName, walletClient.String(), dbAgenda, dbTicket.Hash)
 
 				// If db and wallet are not matching, update wallet with correct

--- a/database/ticket_test.go
+++ b/database/ticket_test.go
@@ -37,7 +37,7 @@ func exampleTicket() Ticket {
 		FeeAmount:         10000000,
 		FeeExpiration:     4,
 		Confirmed:         false,
-		VoteChoices:       map[string]string{"AgendaID": "Choice"},
+		VoteChoices:       map[string]string{"AgendaID": "yes"},
 		VotingWIF:         randString(53, addrCharset),
 		FeeTxHex:          randString(504, hexCharset),
 		FeeTxHash:         randString(64, hexCharset),

--- a/webapi/payfee.go
+++ b/webapi/payfee.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Decred developers
+// Copyright (c) 2020-2021 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -103,7 +103,7 @@ func payFee(c *gin.Context) {
 	err = validConsensusVoteChoices(cfg.NetParams, currentVoteVersion(cfg.NetParams), request.VoteChoices)
 	if err != nil {
 		validVoteChoices = false
-		log.Warnf("%s: Invalid vote choices (clientIP=%s, ticketHash=%s): %v",
+		log.Warnf("%s: Invalid consensus vote choices (clientIP=%s, ticketHash=%s): %v",
 			funcName, c.ClientIP(), ticket.Hash, err)
 	}
 

--- a/webapi/setvotechoices.go
+++ b/webapi/setvotechoices.go
@@ -120,7 +120,7 @@ func setVoteChoices(c *gin.Context) {
 		// to attempt to update as much as possible regardless of any errors.
 		for _, walletClient := range walletClients {
 
-			// Consensus vote choices.
+			// Set consensus vote choices.
 			for agenda, choice := range request.VoteChoices {
 				err = walletClient.SetVoteChoice(agenda, choice, ticket.Hash)
 				if err != nil {

--- a/webapi/setvotechoices.go
+++ b/webapi/setvotechoices.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Decred developers
+// Copyright (c) 2020-2021 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -92,10 +92,9 @@ func setVoteChoices(c *gin.Context) {
 		}
 	}
 
-	voteChoices := request.VoteChoices
-	err = validConsensusVoteChoices(cfg.NetParams, currentVoteVersion(cfg.NetParams), voteChoices)
+	err = validConsensusVoteChoices(cfg.NetParams, currentVoteVersion(cfg.NetParams), request.VoteChoices)
 	if err != nil {
-		log.Warnf("%s: Invalid vote choices (clientIP=%s, ticketHash=%s): %v",
+		log.Warnf("%s: Invalid consensus vote choices (clientIP=%s, ticketHash=%s): %v",
 			funcName, c.ClientIP(), ticket.Hash, err)
 		sendErrorWithMsg(err.Error(), errInvalidVoteChoices, c)
 		return
@@ -103,7 +102,8 @@ func setVoteChoices(c *gin.Context) {
 
 	// Update VoteChoices in the database before updating the wallets. DB is the
 	// source of truth, and also is less likely to error.
-	ticket.VoteChoices = voteChoices
+	ticket.VoteChoices = request.VoteChoices
+
 	err = db.UpdateTicket(ticket)
 	if err != nil {
 		log.Errorf("%s: db.UpdateTicket error, failed to set vote choices (ticketHash=%s): %v",
@@ -115,16 +115,20 @@ func setVoteChoices(c *gin.Context) {
 	// Update vote choices on voting wallets. Tickets are only added to voting
 	// wallets if their fee is confirmed.
 	if ticket.FeeTxStatus == database.FeeConfirmed {
+
+		// Just log any errors which occur while setting vote choices. We want
+		// to attempt to update as much as possible regardless of any errors.
 		for _, walletClient := range walletClients {
-			for agenda, choice := range voteChoices {
+
+			// Consensus vote choices.
+			for agenda, choice := range request.VoteChoices {
 				err = walletClient.SetVoteChoice(agenda, choice, ticket.Hash)
 				if err != nil {
-					// If this fails, we still want to try the other wallets, so
-					// don't return an error response, just log an error.
 					log.Errorf("%s: dcrwallet.SetVoteChoice failed (wallet=%s, ticketHash=%s): %v",
 						funcName, walletClient.String(), ticket.Hash, err)
 				}
 			}
+
 		}
 	}
 

--- a/webapi/templates/admin.html
+++ b/webapi/templates/admin.html
@@ -223,11 +223,11 @@
                                         </tr>
                                     </table>
 
-                                    <h1>Voting</h1>
+                                    <h1>Vote Choices</h1>
                                     
                                     <table id="ticket-table" class="mt-2 mb-4 w-100">
                                         <tr>
-                                            <th>Current Vote Choices</th>
+                                            <th>Consensus Vote Choices</th>
                                             <td>
                                                 {{ range $key, $value := .Ticket.VoteChoices }}
                                                     {{ $key }}: {{ $value }} <br />


### PR DESCRIPTION
Rather than referring to just "Vote choices", refer specifically to "consensus vote choices".

This will be useful when treasury and tspend vote choices are added, and the distinction becomes more important.

This is similar to #262 - minor standalone bits which were changing while implementing #234 