### PR TITLE
Use go 1.16 features

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -17,11 +17,7 @@ jobs:
       - name: Install Linters
         run: "curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.42.0"
       - name: Build
-        env:
-          GO111MODULE: "on"
         run: go build ./...
       - name: Test
-        env:
-          GO111MODULE: "on"
         run: |
           ./run_tests.sh

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ VSP will add the ticket to a pool of always-online voting wallets.
 
 ## Implementation
 
-vspd is built and tested on go 1.15 and 1.16, making use of the following
+vspd is built and tested on go 1.16 and 1.17, making use of the following
 libraries:
 
 - [gin-gonic/gin](https://github.com/gin-gonic/gin) webserver.

--- a/config.go
+++ b/config.go
@@ -7,7 +7,6 @@ package main
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"os/user"
@@ -325,7 +324,7 @@ func loadConfig() (*config, error) {
 
 	// Load dcrd RPC certificate.
 	cfg.DcrdCert = cleanAndExpandPath(cfg.DcrdCert)
-	cfg.dcrdCert, err = ioutil.ReadFile(cfg.DcrdCert)
+	cfg.dcrdCert, err = os.ReadFile(cfg.DcrdCert)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read dcrd cert file: %w", err)
 	}
@@ -377,7 +376,7 @@ func loadConfig() (*config, error) {
 	cfg.walletCerts = make([][]byte, numCert)
 	for i := 0; i < numCert; i++ {
 		certs[i] = cleanAndExpandPath(certs[i])
-		cfg.walletCerts[i], err = ioutil.ReadFile(certs[i])
+		cfg.walletCerts[i], err = os.ReadFile(certs[i])
 		if err != nil {
 			return nil, fmt.Errorf("failed to read dcrwallet cert file: %w", err)
 		}

--- a/database/database_test.go
+++ b/database/database_test.go
@@ -7,7 +7,7 @@ package database
 import (
 	"context"
 	"crypto/ed25519"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -152,7 +152,7 @@ func testHTTPBackup(t *testing.T) {
 	}
 
 	// Check reported length matches actual.
-	body, err := ioutil.ReadAll(rr.Result().Body)
+	body, err := io.ReadAll(rr.Result().Body)
 	if err != nil {
 		t.Fatalf("could not read http response body: %v", err)
 	}

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2020 The Decred developers
+# Copyright (c) 2020-2021 The Decred developers
 # Use of this source code is governed by an ISC
 # license that can be found in the LICENSE file.
 #
@@ -10,17 +10,6 @@
 set -ex
 
 go version
-
-# run `go mod download` and `go mod tidy` and fail if the git status of
-# go.mod and/or go.sum changes
-MOD_STATUS=$(git status --porcelain go.mod go.sum)
-go mod download
-go mod tidy
-UPDATED_MOD_STATUS=$(git status --porcelain go.mod go.sum)
-if [ "$UPDATED_MOD_STATUS" != "$MOD_STATUS" ]; then
-    echo "Running `go mod tidy` modified go.mod and/or go.sum"
-    exit 1
-fi
 
 # run tests
 env GORACE="halt_on_error=1" go test -race ./...

--- a/webapi/middleware.go
+++ b/webapi/middleware.go
@@ -7,7 +7,7 @@ package webapi
 import (
 	"bytes"
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 
@@ -106,12 +106,12 @@ func withWalletClients(wallets rpc.WalletConnect) gin.HandlerFunc {
 // drainAndReplaceBody will read and return the body of the provided request. It
 // replaces the request reader with an identical one so it can be used again.
 func drainAndReplaceBody(req *http.Request) ([]byte, error) {
-	reqBytes, err := ioutil.ReadAll(req.Body)
+	reqBytes, err := io.ReadAll(req.Body)
 	if err != nil {
 		return nil, err
 	}
 	req.Body.Close()
-	req.Body = ioutil.NopCloser(bytes.NewBuffer(reqBytes))
+	req.Body = io.NopCloser(bytes.NewBuffer(reqBytes))
 	return reqBytes, nil
 }
 

--- a/webapi/recovery.go
+++ b/webapi/recovery.go
@@ -3,7 +3,6 @@ package webapi
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/http/httputil"
@@ -70,7 +69,7 @@ func formattedStack() []byte {
 		// Print this much at least. If we can't find the source, it won't show.
 		fmt.Fprintf(buf, "%s:%d (0x%x)\n", file, line, pc)
 		if file != lastFile {
-			data, err := ioutil.ReadFile(file)
+			data, err := os.ReadFile(file)
 			if err != nil {
 				continue
 			}


### PR DESCRIPTION
Now that Go 1.16 is the minimum supported version, we can take advantage of new features introduced in 1.16.

- Use features from Go 1.16 tooling
    - GO111MODULE environment variable now defaults to "on"
    - "go build" and "go test" now exit with an error rather than silently modifying go.mod or go.sum files
    - Update README.md

- Don't use deprecated ioutil package