### PR TITLE
Update shutdown signalling.

### DIFF
--- a/signal_unix.go
+++ b/signal_unix.go
@@ -1,4 +1,5 @@
 // Copyright (c) 2016 The btcsuite developers
+// Copyright (c) 2021 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -12,5 +13,9 @@ import (
 )
 
 func init() {
-	signals = []os.Signal{os.Interrupt, syscall.SIGTERM}
+	interruptSignals = []os.Signal{
+		os.Interrupt,
+		syscall.SIGTERM,
+		syscall.SIGHUP,
+	}
 }

--- a/vspd.go
+++ b/vspd.go
@@ -104,7 +104,7 @@ func run(ctx context.Context) error {
 		MaxVoteChangeRecords: maxVoteChangeRecords,
 		VspdVersion:          version.String(),
 	}
-	err = webapi.Start(ctx, shutdownRequestChannel, &shutdownWg, cfg.Listen, db,
+	err = webapi.Start(ctx, requestShutdown, &shutdownWg, cfg.Listen, db,
 		dcrd, wallets, apiCfg)
 	if err != nil {
 		log.Errorf("Failed to initialize webapi: %v", err)

--- a/webapi/webapi.go
+++ b/webapi/webapi.go
@@ -55,7 +55,7 @@ var addrGen *addressGenerator
 var signPrivKey ed25519.PrivateKey
 var signPubKey ed25519.PublicKey
 
-func Start(ctx context.Context, requestShutdownChan chan struct{}, shutdownWg *sync.WaitGroup,
+func Start(ctx context.Context, requestShutdown func(), shutdownWg *sync.WaitGroup,
 	listen string, vdb *database.VspDatabase, dcrd rpc.DcrdConnect, wallets rpc.WalletConnect, config Config) error {
 
 	cfg = config
@@ -137,7 +137,7 @@ func Start(ctx context.Context, requestShutdownChan chan struct{}, shutdownWg *s
 		// shutdown.
 		if err != nil && !errors.Is(err, http.ErrServerClosed) {
 			log.Errorf("Unexpected webserver error: %v", err)
-			requestShutdownChan <- struct{}{}
+			requestShutdown()
 		}
 	}()
 


### PR DESCRIPTION
Bring in some updates from the signal handling code in other projects:

- Rename `signals` to more descriptive `interruptSignals`.
- Add SIGHUP to unix shutdown signals. Rename `signalsigterm.go` to `signal_unix.go` accordingly.
- Include extra detail in "Already shutting down..." messages log lines.
- Pass a shutdown func into `webapi.go` rather than a channel. It's more obvious how to invoke a func, whereas a channel can be used in multiple ways.