### PR TITLE
Use reflect.DeepEqual where possible.

### DIFF
--- a/database/ticket_test.go
+++ b/database/ticket_test.go
@@ -125,18 +125,7 @@ func testGetTicketByHash(t *testing.T) {
 	}
 
 	// Check ticket fields match expected.
-	if retrieved.Hash != ticket.Hash ||
-		retrieved.CommitmentAddress != ticket.CommitmentAddress ||
-		retrieved.FeeAddressIndex != ticket.FeeAddressIndex ||
-		retrieved.FeeAddress != ticket.FeeAddress ||
-		retrieved.FeeAmount != ticket.FeeAmount ||
-		retrieved.FeeExpiration != ticket.FeeExpiration ||
-		retrieved.Confirmed != ticket.Confirmed ||
-		!reflect.DeepEqual(retrieved.VoteChoices, ticket.VoteChoices) ||
-		retrieved.VotingWIF != ticket.VotingWIF ||
-		retrieved.FeeTxHex != ticket.FeeTxHex ||
-		retrieved.FeeTxHash != ticket.FeeTxHash ||
-		retrieved.FeeTxStatus != ticket.FeeTxStatus {
+	if !reflect.DeepEqual(retrieved, ticket) {
 		t.Fatal("retrieved ticket value didnt match expected")
 	}
 
@@ -177,9 +166,7 @@ func testUpdateTicket(t *testing.T) {
 		t.Fatal("expected found==true")
 	}
 
-	if ticket.FeeAmount != retrieved.FeeAmount ||
-		ticket.FeeExpiration != retrieved.FeeExpiration ||
-		!reflect.DeepEqual(retrieved.VoteChoices, ticket.VoteChoices) {
+	if !reflect.DeepEqual(retrieved, ticket) {
 		t.Fatal("retrieved ticket value didnt match expected")
 	}
 

--- a/database/votechange_test.go
+++ b/database/votechange_test.go
@@ -5,6 +5,7 @@
 package database
 
 import (
+	"reflect"
 	"testing"
 )
 
@@ -33,11 +34,7 @@ func testVoteChangeRecords(t *testing.T) {
 		t.Fatalf("error retrieving vote change records: %v", err)
 	}
 
-	if len(retrieved) != 1 ||
-		retrieved[0].Request != record.Request ||
-		retrieved[0].RequestSignature != record.RequestSignature ||
-		retrieved[0].Response != record.Response ||
-		retrieved[0].ResponseSignature != record.ResponseSignature {
+	if len(retrieved) != 1 || !reflect.DeepEqual(retrieved[0], record) {
 		t.Fatal("retrieved record didnt match expected")
 	}
 


### PR DESCRIPTION
Comparing each field manually is unnecessary and error-prone.