### PR TITLE
Use latest dcrd RPC version.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/decred/dcrd/wire v1.4.1-0.20210525214639-70483c835b7f
 	github.com/decred/slog v1.2.0
 	github.com/dustin/go-humanize v1.0.0
-	github.com/gin-gonic/gin v1.7.3
+	github.com/gin-gonic/gin v1.7.4
 	github.com/gorilla/sessions v1.2.1
 	github.com/jessevdk/go-flags v1.5.0
 	github.com/jrick/bitset v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -98,6 +98,8 @@ github.com/gin-contrib/sse v0.1.0 h1:Y/yl/+YNO8GZSjAhjMsSuLt29uWRFHdHYUb5lYOV9qE
 github.com/gin-contrib/sse v0.1.0/go.mod h1:RHrZQHXnP2xjPF+u1gW/2HnVO7nvIa9PG3Gm+fLHvGI=
 github.com/gin-gonic/gin v1.7.3 h1:aMBzLJ/GMEYmv1UWs2FFTcPISLrQH2mRgL9Glz8xows=
 github.com/gin-gonic/gin v1.7.3/go.mod h1:jD2toBW3GZUr5UMcdrwQA10I7RuaFOl/SGeDjXkfUtY=
+github.com/gin-gonic/gin v1.7.4 h1:QmUZXrvJ9qZ3GfWvQ+2wnW/1ePrTEJqPKMYEU3lD/DM=
+github.com/gin-gonic/gin v1.7.4/go.mod h1:jD2toBW3GZUr5UMcdrwQA10I7RuaFOl/SGeDjXkfUtY=
 github.com/go-playground/assert/v2 v2.0.1 h1:MsBgLAaY856+nPRTKrp3/OZK38U/wa0CcBYNjji3q3A=
 github.com/go-playground/assert/v2 v2.0.1/go.mod h1:VDjEfimB/XKnb+ZQfWdccd7VUvScMdVu0Titje2rxJ4=
 github.com/go-playground/locales v0.13.0 h1:HyWk6mgj5qFqCT5fjGBuRArbVDfE4hi8+e8ceBS/t7Q=

--- a/rpc/dcrd.go
+++ b/rpc/dcrd.go
@@ -20,7 +20,7 @@ import (
 )
 
 var (
-	requiredDcrdVersion = semver{Major: 6, Minor: 1, Patch: 2}
+	requiredDcrdVersion = semver{Major: 7, Minor: 0, Patch: 0}
 )
 
 // These error codes are defined in dcrd/dcrjson. They are copied here so we


### PR DESCRIPTION
This commit marks the point at which vspd will stop working against dcrd 1.6 and start to target master.

The dcrwallet RPC version has not changed, so vspd continues to work with dcrwallet 1.6 or master.