### PR TITLE
Add dcrd to VSP status (UI and API)

### DIFF
--- a/background/background.go
+++ b/background/background.go
@@ -71,7 +71,7 @@ func blockConnected() {
 
 	ctx := context.Background()
 
-	dcrdClient, err := dcrdRPC.Client(ctx, netParams)
+	dcrdClient, _, err := dcrdRPC.Client(ctx, netParams)
 	if err != nil {
 		log.Errorf("%s: %v", funcName, err)
 		return
@@ -314,7 +314,7 @@ func (n *NotificationHandler) Close() error {
 func connectNotifier(shutdownCtx context.Context, dcrdWithNotifs rpc.DcrdConnect) error {
 	notifierClosed = make(chan struct{})
 
-	dcrdClient, err := dcrdWithNotifs.Client(shutdownCtx, netParams)
+	dcrdClient, _, err := dcrdWithNotifs.Client(shutdownCtx, netParams)
 	if err != nil {
 		return err
 	}
@@ -411,7 +411,7 @@ func checkWalletConsistency() {
 
 	ctx := context.Background()
 
-	dcrdClient, err := dcrdRPC.Client(ctx, netParams)
+	dcrdClient, _, err := dcrdRPC.Client(ctx, netParams)
 	if err != nil {
 		log.Errorf("%s: %v", funcName, err)
 		return

--- a/database/database.go
+++ b/database/database.go
@@ -436,7 +436,7 @@ func (vdb *VspDatabase) CheckIntegrity(ctx context.Context, params *chaincfg.Par
 		return nil
 	}
 
-	dcrdClient, err := dcrd.Client(ctx, params)
+	dcrdClient, _, err := dcrd.Client(ctx, params)
 	if err != nil {
 		return err
 	}

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -118,13 +118,13 @@ The `[WRN]` level is used to indicate events which are of interest, but do not
 necessarily require investigation (eg. bad requests from clients, recoverable
 errors).
 
-### Voting Wallet Status
+### VSP Status
 
-The current status of the voting wallets is displayed in a table on the `/admin`
+The current status of the VSP is displayed in a table on the `/admin`
 page, and the same information can be retrieved as a JSON object from
 `/admin/status` for automated monitoring. This endpoint requires Basic HTTP
 Authentication with the username `admin` and the password set in vspd
-configuration. A 200 HTTP status will be returned if the voting wallets seem
+configuration. A 200 HTTP status will be returned if the VSP seems
 healthy, or a 500 status will be used to indicate something is wrong.
 
 ```bash
@@ -133,17 +133,24 @@ $ curl --user admin:12345 --request GET http://localhost:8800/admin/status
 
 ```json
 {
-  "wss://127.0.0.1:20111/ws":
-    {
-      "connected":true,
-      "infoerror":false,
-      "daemonconnected":true,
-      "voteversion":8,
-      "unlocked":true,
-      "voting":true,
-      "bestblockerror":false,
-      "bestblockheight":462345
+  "dcrd": {
+    "host": "wss://127.0.0.1:19109/ws",
+    "connected": true,
+    "bestblockerror": false,
+    "bestblockheight": 802572
+  },
+  "wallets": {
+    "wss://127.0.0.1:20111/ws": {
+      "connected": true,
+      "infoerror": false,
+      "daemonconnected": true,
+      "voteversion": 10,
+      "unlocked": true,
+      "voting": true,
+      "bestblockerror": false,
+      "bestblockheight": 802572
     }
+  }
 }
 ```
 

--- a/signal_unix.go
+++ b/signal_unix.go
@@ -3,6 +3,7 @@
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
+//go:build darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris
 // +build darwin dragonfly freebsd linux netbsd openbsd solaris
 
 package main

--- a/webapi/admin.go
+++ b/webapi/admin.go
@@ -47,11 +47,11 @@ type searchResult struct {
 }
 
 func dcrdStatus(c *gin.Context) DcrdStatus {
-	hostname := c.MustGet("DcrdHostname").(string)
+	hostname := c.MustGet(dcrdHostKey).(string)
 	status := DcrdStatus{Host: hostname}
 
-	dcrdClient := c.MustGet("DcrdClient").(*rpc.DcrdRPC)
-	dcrdErr := c.MustGet("DcrdClientErr")
+	dcrdClient := c.MustGet(dcrdKey).(*rpc.DcrdRPC)
+	dcrdErr := c.MustGet(dcrdErrorKey)
 	if dcrdErr != nil {
 		log.Errorf("could not get dcrd client: %v", dcrdErr.(error))
 		return status
@@ -72,8 +72,8 @@ func dcrdStatus(c *gin.Context) DcrdStatus {
 }
 
 func walletStatus(c *gin.Context) map[string]WalletStatus {
-	walletClients := c.MustGet("WalletClients").([]*rpc.WalletRPC)
-	failedWalletClients := c.MustGet("FailedWalletClients").([]string)
+	walletClients := c.MustGet(walletsKey).([]*rpc.WalletRPC)
+	failedWalletClients := c.MustGet(failedWalletsKey).([]string)
 
 	walletStatus := make(map[string]WalletStatus)
 	for _, v := range walletClients {
@@ -236,7 +236,7 @@ func downloadDatabaseBackup(c *gin.Context) {
 // setAdminStatus stores the authentication status of the current session and
 // redirects the client to GET /admin.
 func setAdminStatus(admin interface{}, c *gin.Context) {
-	session := c.MustGet("session").(*sessions.Session)
+	session := c.MustGet(sessionKey).(*sessions.Session)
 	session.Values["admin"] = admin
 	err := session.Save(c.Request, c.Writer)
 	if err != nil {

--- a/webapi/cache.go
+++ b/webapi/cache.go
@@ -69,7 +69,7 @@ func updateCache(ctx context.Context, db *database.VspDatabase,
 	}
 
 	// Get latest best block height.
-	dcrdClient, err := dcrd.Client(ctx, netParams)
+	dcrdClient, _, err := dcrd.Client(ctx, netParams)
 	if err != nil {
 		return err
 	}

--- a/webapi/getfeeaddress.go
+++ b/webapi/getfeeaddress.go
@@ -76,6 +76,12 @@ func feeAddress(c *gin.Context) {
 	knownTicket := c.MustGet("KnownTicket").(bool)
 	commitmentAddress := c.MustGet("CommitmentAddress").(string)
 	dcrdClient := c.MustGet("DcrdClient").(*rpc.DcrdRPC)
+	dcrdErr := c.MustGet("DcrdClientErr")
+	if dcrdErr != nil {
+		log.Errorf("%s: could not get dcrd client: %v", funcName, dcrdErr.(error))
+		sendError(errInternalError, c)
+		return
+	}
 	reqBytes := c.MustGet("RequestBytes").([]byte)
 
 	if cfg.VspClosed {

--- a/webapi/getfeeaddress.go
+++ b/webapi/getfeeaddress.go
@@ -72,17 +72,17 @@ func feeAddress(c *gin.Context) {
 	const funcName = "feeAddress"
 
 	// Get values which have been added to context by middleware.
-	ticket := c.MustGet("Ticket").(database.Ticket)
-	knownTicket := c.MustGet("KnownTicket").(bool)
-	commitmentAddress := c.MustGet("CommitmentAddress").(string)
-	dcrdClient := c.MustGet("DcrdClient").(*rpc.DcrdRPC)
-	dcrdErr := c.MustGet("DcrdClientErr")
+	ticket := c.MustGet(ticketKey).(database.Ticket)
+	knownTicket := c.MustGet(knownTicketKey).(bool)
+	commitmentAddress := c.MustGet(commitmentAddressKey).(string)
+	dcrdClient := c.MustGet(dcrdKey).(*rpc.DcrdRPC)
+	dcrdErr := c.MustGet(dcrdErrorKey)
 	if dcrdErr != nil {
 		log.Errorf("%s: could not get dcrd client: %v", funcName, dcrdErr.(error))
 		sendError(errInternalError, c)
 		return
 	}
-	reqBytes := c.MustGet("RequestBytes").([]byte)
+	reqBytes := c.MustGet(requestBytesKey).([]byte)
 
 	if cfg.VspClosed {
 		sendError(errVspClosed, c)

--- a/webapi/middleware.go
+++ b/webapi/middleware.go
@@ -75,10 +75,11 @@ func requireAdmin() gin.HandlerFunc {
 // downstream handlers to make use of.
 func withDcrdClient(dcrd rpc.DcrdConnect) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		client, err := dcrd.Client(c, cfg.NetParams)
+		client, hostname, err := dcrd.Client(c, cfg.NetParams)
 		// Don't handle the error here, add it to the context and let downstream
 		// handlers decide what to do with it.
 		c.Set("DcrdClient", client)
+		c.Set("DcrdHostname", hostname)
 		c.Set("DcrdClientErr", err)
 	}
 }

--- a/webapi/payfee.go
+++ b/webapi/payfee.go
@@ -27,6 +27,12 @@ func payFee(c *gin.Context) {
 	ticket := c.MustGet("Ticket").(database.Ticket)
 	knownTicket := c.MustGet("KnownTicket").(bool)
 	dcrdClient := c.MustGet("DcrdClient").(*rpc.DcrdRPC)
+	dcrdErr := c.MustGet("DcrdClientErr")
+	if dcrdErr != nil {
+		log.Errorf("%s: could not get dcrd client: %v", funcName, dcrdErr.(error))
+		sendError(errInternalError, c)
+		return
+	}
 	reqBytes := c.MustGet("RequestBytes").([]byte)
 
 	if cfg.VspClosed {

--- a/webapi/payfee.go
+++ b/webapi/payfee.go
@@ -24,16 +24,16 @@ func payFee(c *gin.Context) {
 	const funcName = "payFee"
 
 	// Get values which have been added to context by middleware.
-	ticket := c.MustGet("Ticket").(database.Ticket)
-	knownTicket := c.MustGet("KnownTicket").(bool)
-	dcrdClient := c.MustGet("DcrdClient").(*rpc.DcrdRPC)
-	dcrdErr := c.MustGet("DcrdClientErr")
+	ticket := c.MustGet(ticketKey).(database.Ticket)
+	knownTicket := c.MustGet(knownTicketKey).(bool)
+	dcrdClient := c.MustGet(dcrdKey).(*rpc.DcrdRPC)
+	dcrdErr := c.MustGet(dcrdErrorKey)
 	if dcrdErr != nil {
 		log.Errorf("%s: could not get dcrd client: %v", funcName, dcrdErr.(error))
 		sendError(errInternalError, c)
 		return
 	}
-	reqBytes := c.MustGet("RequestBytes").([]byte)
+	reqBytes := c.MustGet(requestBytesKey).([]byte)
 
 	if cfg.VspClosed {
 		sendError(errVspClosed, c)

--- a/webapi/public/css/vspd.css
+++ b/webapi/public/css/vspd.css
@@ -151,34 +151,41 @@ footer .code {
     font-size: 12px;
 }
 
+.vsp-status {
+    padding: 10px;
+}
 
-#status-table th,
-#status-table td {
+.vsp-status table {
+    margin-bottom: 28px;
+}
+
+.vsp-status table th,
+.vsp-status table td {
     border: 1px solid #edeff1;
     vertical-align: middle;
     text-align: center;
 }
 
-#status-table .center {
+.vsp-status table .center {
     display: flex;
     justify-content: center;
     align-items: center;
 }
 
-#status-table .status {
+.vsp-status table .status {
     height: 30px;
     padding-left: 30px;
 }
 
-#status-table .good {
+.vsp-status table .good {
     background: url(/public/images/success-icon.svg) no-repeat center center;
 }
 
-#status-table .bad {
+.vsp-status table .bad {
     background: url(/public/images/error-icon.svg) no-repeat left center;
 }
 
-#status-table .with-text {
+.vsp-status table .with-text {
     padding-left: 40px;
 }
 

--- a/webapi/setaltsig.go
+++ b/webapi/setaltsig.go
@@ -32,6 +32,12 @@ func setAltSig(c *gin.Context) {
 
 	// Get values which have been added to context by middleware.
 	dcrdClient := c.MustGet("DcrdClient").(Node)
+	dcrdErr := c.MustGet("DcrdClientErr")
+	if dcrdErr != nil {
+		log.Errorf("%s: could not get dcrd client: %v", funcName, dcrdErr.(error))
+		sendError(errInternalError, c)
+		return
+	}
 	reqBytes := c.MustGet("RequestBytes").([]byte)
 
 	if cfg.VspClosed {

--- a/webapi/setaltsig.go
+++ b/webapi/setaltsig.go
@@ -31,14 +31,14 @@ func setAltSig(c *gin.Context) {
 	const funcName = "setAltSig"
 
 	// Get values which have been added to context by middleware.
-	dcrdClient := c.MustGet("DcrdClient").(Node)
-	dcrdErr := c.MustGet("DcrdClientErr")
+	dcrdClient := c.MustGet(dcrdKey).(Node)
+	dcrdErr := c.MustGet(dcrdErrorKey)
 	if dcrdErr != nil {
 		log.Errorf("%s: could not get dcrd client: %v", funcName, dcrdErr.(error))
 		sendError(errInternalError, c)
 		return
 	}
-	reqBytes := c.MustGet("RequestBytes").([]byte)
+	reqBytes := c.MustGet(requestBytesKey).([]byte)
 
 	if cfg.VspClosed {
 		sendError(errVspClosed, c)

--- a/webapi/setaltsig_test.go
+++ b/webapi/setaltsig_test.go
@@ -220,9 +220,9 @@ func TestSetAltSig(t *testing.T) {
 		}
 
 		handle := func(c *gin.Context) {
-			c.Set("DcrdClient", tNode)
-			c.Set("DcrdClientErr", dcrdErr)
-			c.Set("RequestBytes", b[test.deformReq:])
+			c.Set(dcrdKey, tNode)
+			c.Set(dcrdErrorKey, dcrdErr)
+			c.Set(requestBytesKey, b[test.deformReq:])
 			setAltSig(c)
 		}
 

--- a/webapi/setaltsig_test.go
+++ b/webapi/setaltsig_test.go
@@ -119,6 +119,7 @@ func TestSetAltSig(t *testing.T) {
 	const testAddr = "DsVoDXNQqyF3V83PJJ5zMdnB4pQuJHBAh15"
 	tests := []struct {
 		name                 string
+		dcrdClientErr        bool
 		vspClosed            bool
 		deformReq            int
 		addr                 string
@@ -136,6 +137,11 @@ func TestSetAltSig(t *testing.T) {
 		vspClosed: true,
 		wantCode:  http.StatusBadRequest,
 	}, {
+		name:          "dcrd client error",
+		dcrdClientErr: true,
+		wantCode:      http.StatusInternalServerError,
+	}, {
+
 		name:      "bad request",
 		deformReq: 1,
 		wantCode:  http.StatusBadRequest,
@@ -207,8 +213,15 @@ func TestSetAltSig(t *testing.T) {
 		w := httptest.NewRecorder()
 		c, r := gin.CreateTestContext(w)
 
+		var dcrdErr error
+		if test.dcrdClientErr {
+			tNode = nil
+			dcrdErr = errors.New("error")
+		}
+
 		handle := func(c *gin.Context) {
 			c.Set("DcrdClient", tNode)
+			c.Set("DcrdClientErr", dcrdErr)
 			c.Set("RequestBytes", b[test.deformReq:])
 			setAltSig(c)
 		}

--- a/webapi/setvotechoices.go
+++ b/webapi/setvotechoices.go
@@ -20,10 +20,10 @@ func setVoteChoices(c *gin.Context) {
 	const funcName = "setVoteChoices"
 
 	// Get values which have been added to context by middleware.
-	ticket := c.MustGet("Ticket").(database.Ticket)
-	knownTicket := c.MustGet("KnownTicket").(bool)
-	walletClients := c.MustGet("WalletClients").([]*rpc.WalletRPC)
-	reqBytes := c.MustGet("RequestBytes").([]byte)
+	ticket := c.MustGet(ticketKey).(database.Ticket)
+	knownTicket := c.MustGet(knownTicketKey).(bool)
+	walletClients := c.MustGet(walletsKey).([]*rpc.WalletRPC)
+	reqBytes := c.MustGet(requestBytesKey).([]byte)
 
 	// If we cannot set the vote choices on at least one voting wallet right
 	// now, don't update the database, just return an error.

--- a/webapi/templates/admin.html
+++ b/webapi/templates/admin.html
@@ -46,7 +46,7 @@
                         hidden
                     >
                     <ul>
-                        <li><label for="tabset_1_1">Wallet Status</label></li>
+                        <li><label for="tabset_1_1">VSP Status</label></li>
                         <li><label for="tabset_1_2">Ticket Search</label></li>
                         <li><label for="tabset_1_3">Database</label></li>
                         <li><label for="tabset_1_4">Logout</label></li>
@@ -54,80 +54,126 @@
                     
                     <div>
 
-                        <section>
-                            <table id="status-table" class="w-100 mb-0">
-                                <thead>
-                                    <th>URL</th>
-                                    <th>Height</th>
-                                    <th>Connected</th>
-                                    <th>Unlocked</th>
-                                    <th>Voting</th>
-                                    <th>Vote Version</th>
-                                </thead>
-                                <tbody>
-                                    {{ range $host, $status := .WalletStatus }}
-                                    <tr>
-                                        <td>{{ stripWss $host }}</td>
+                        <section class="d-flex row justify-content-center">
+
+                            <div class="vsp-status">
+                                <h1>Local dcrd</h1>
+
+                                <table class="vsp-status">
+                                    <thead>
+                                        <th>URL</th>
+                                        <th>Height</th>
+                                    </thead>
+                                    <tbody>
+                                        <tr>
+                                            <td>{{ stripWss .DcrdStatus.Host }}</td>
+                                            
+                                            {{ if .DcrdStatus.Connected }}
+                    
+                                                {{ if .DcrdStatus.BestBlockError }}
+                                                    <td>
+                                                        <div class="center">
+                                                            <div class="status bad center with-text">
+                                                                Error
+                                                            </div>
+                                                        </div>
+                                                    </td>
+                                                {{ else }}
+                                                    <td>{{ .DcrdStatus.BestBlockHeight }}</td>
+                                                {{ end }}
+                    
+                                            {{else}}
+                                                <td>
+                                                    <div class="center">
+                                                        <div class="status bad center with-text">
+                                                            Cannot connect
+                                                        </div>
+                                                    </div>
+                                                </td>
+                                            {{end}}
+                                        </tr>
+                                    </tbody>
+                                </table>
+                            </div>
+                            
+                            <div class="vsp-status">
+                                <h1>Voting Wallets</h1>
+
+                                <table class="vsp-status">
+                                    <thead>
+                                        <th>URL</th>
+                                        <th>Height</th>
+                                        <th>Connected<br />to dcrd</th>
+                                        <th>Unlocked</th>
+                                        <th>Voting</th>
+                                        <th>Vote<br />Version</th>
+                                    </thead>
+                                    <tbody>
+                                        {{ range $host, $status := .WalletStatus }}
+                                        <tr>
+                                            <td>{{ stripWss $host }}</td>
                                         
-                                        {{ if $status.Connected }}
+                                            {{ if $status.Connected }}
                 
-                                            {{ if $status.BestBlockError }}
-                                                <td>
+                                                {{ if $status.BestBlockError }}
+                                                    <td>
+                                                        <div class="center">
+                                                            <div class="status bad center with-text">
+                                                                Error
+                                                            </div>
+                                                        </div>
+                                                    </td>
+                                                {{ else }}
+                                                    <td>{{ $status.BestBlockHeight }}</td>
+                                                {{ end }}
+                
+                                                {{ if $status.InfoError }}
+                                                    <td colspan="4">
+                                                        <div class="center">
+                                                            <div class="status bad center with-text">
+                                                                Error getting wallet info
+                                                            </div>
+                                                        </div>
+                                                    </td>
+                                                {{ else }}
+                                                    <td>
+                                                        <div class="center">
+                                                            <div class="status {{ if $status.DaemonConnected }}good{{else}}bad{{end}}"></div>
+                                                        </div>
+                                                    </td>
+                                                
+                                                
+                                                    <td>
+                                                        <div class="center">
+                                                            <div class="status {{ if $status.Unlocked }}good{{else}}bad{{end}}"></div>
+                                                        </div>
+                                                    </td>
+                                                
+                                                
+                                                    <td>
+                                                        <div class="center">
+                                                            <div class="status {{ if $status.Voting }}good{{else}}bad{{end}}"></div>
+                                                        </div>
+                                                    </td>
+                                                
+                                                    <td>{{ $status.VoteVersion }}</td>
+                                                {{ end }}
+                
+                                            {{else}}
+                                                <td colspan="5">
                                                     <div class="center">
                                                         <div class="status bad center with-text">
-                                                            Error
+                                                            Cannot connect to wallet
                                                         </div>
                                                     </div>
                                                 </td>
-                                            {{ else }}
-                                                <td>{{ $status.BestBlockHeight }}</td>
-                                            {{ end }}
-                
-                                            {{ if $status.InfoError }}
-                                                <td colspan="4">
-                                                    <div class="center">
-                                                        <div class="status bad center with-text">
-                                                            Error getting wallet info
-                                                        </div>
-                                                    </div>
-                                                </td>
-                                            {{ else }}
-                                                <td>
-                                                    <div class="center">
-                                                        <div class="status {{ if $status.DaemonConnected }}good{{else}}bad{{end}}"></div>
-                                                    </div>
-                                                </td>
-                                                
-                                                
-                                                <td>
-                                                    <div class="center">
-                                                        <div class="status {{ if $status.Unlocked }}good{{else}}bad{{end}}"></div>
-                                                    </div>
-                                                </td>
-                                                
-                                                
-                                                <td>
-                                                    <div class="center">
-                                                        <div class="status {{ if $status.Voting }}good{{else}}bad{{end}}"></div>
-                                                    </div>
-                                                </td>
-                                                
-                                                <td>{{ $status.VoteVersion }}</td>
-                                            {{ end }}
-                
-                                        {{else}}
-                                            <td colspan="5">
-                                                <div class="center">
-                                                    <div class="status bad center with-text">
-                                                        Cannot connect to wallet
-                                                    </div>
-                                                </div>
-                                            </td>
+                                            {{end}}
+                                        </tr>
                                         {{end}}
-                                    </tr>
-                                    {{end}}
-                                </tbody>
-                            </table>
+                                    </tbody>
+                                </table>
+                            </div>
+
                         </section>
                         
                         <section>

--- a/webapi/ticketstatus.go
+++ b/webapi/ticketstatus.go
@@ -17,9 +17,9 @@ func ticketStatus(c *gin.Context) {
 	const funcName = "ticketStatus"
 
 	// Get values which have been added to context by middleware.
-	ticket := c.MustGet("Ticket").(database.Ticket)
-	knownTicket := c.MustGet("KnownTicket").(bool)
-	reqBytes := c.MustGet("RequestBytes").([]byte)
+	ticket := c.MustGet(ticketKey).(database.Ticket)
+	knownTicket := c.MustGet(knownTicketKey).(bool)
+	reqBytes := c.MustGet(requestBytesKey).([]byte)
 
 	if !knownTicket {
 		log.Warnf("%s: Unknown ticket (clientIP=%s)", funcName, c.ClientIP())

--- a/webapi/webapi.go
+++ b/webapi/webapi.go
@@ -232,14 +232,14 @@ func router(debugMode bool, cookieSecret []byte, dcrd rpc.DcrdConnect, wallets r
 	admin := router.Group("/admin").Use(
 		withWalletClients(wallets), withSession(cookieStore), requireAdmin(),
 	)
-	admin.GET("", adminPage)
-	admin.POST("/ticket", ticketSearch)
+	admin.GET("", withDcrdClient(dcrd), adminPage)
+	admin.POST("/ticket", withDcrdClient(dcrd), ticketSearch)
 	admin.GET("/backup", downloadDatabaseBackup)
 	admin.POST("/logout", adminLogout)
 
 	// Require Basic HTTP Auth on /admin/status endpoint.
 	basic := router.Group("/admin").Use(
-		withWalletClients(wallets), gin.BasicAuth(gin.Accounts{
+		withDcrdClient(dcrd), withWalletClients(wallets), gin.BasicAuth(gin.Accounts{
 			"admin": cfg.AdminPass,
 		}),
 	)

--- a/webapi/webapi.go
+++ b/webapi/webapi.go
@@ -49,6 +49,20 @@ const (
 	feeAddressExpiration = 1 * time.Hour
 )
 
+// Hard-coded keys used for storing values in the web context.
+const (
+	sessionKey           = "Session"
+	dcrdKey              = "DcrdClient"
+	dcrdHostKey          = "DcrdHostname"
+	dcrdErrorKey         = "DcrdClientErr"
+	walletsKey           = "WalletClients"
+	failedWalletsKey     = "FailedWalletClients"
+	requestBytesKey      = "RequestBytes"
+	ticketKey            = "Ticket"
+	knownTicketKey       = "KnownTicket"
+	commitmentAddressKey = "CommitmentAddress"
+)
+
 var cfg Config
 var db *database.VspDatabase
 var addrGen *addressGenerator


### PR DESCRIPTION
This renames "Voting wallet status" to "VSP status" and it now includes the status of the local dcrd instance. This change impacts both the /admin page of the UI, and the response of the /admin/status API endpoint. Closes #286 

### Before

![Screenshot from 2021-11-03 09-59-40](https://user-images.githubusercontent.com/6762864/140040621-f27118fc-2c45-44ab-94d1-b41cc2f6ab82.png)

### After

![Screenshot from 2021-11-03 09-59-27](https://user-images.githubusercontent.com/6762864/140040631-f970dbd5-881d-469b-b158-a9dce83a5503.png)