### PR TITLE
Show AltSignAddr req/resp data in admin UI

### DIFF
--- a/database/altsignaddr.go
+++ b/database/altsignaddr.go
@@ -26,13 +26,13 @@ type AltSignAddrData struct {
 	// AltSignAddr is the new alternate signing address. It is base 58 encoded.
 	AltSignAddr string
 	// Req is the original request to set an alternate signing address.
-	Req []byte
+	Req string
 	// ReqSig is the request's signature signed by the commitment address of the
 	// corresponding ticket. It is base 64 encoded.
 	ReqSig string
 	// Resp is the original response from the server to the alternate signing
 	// address.
-	Resp []byte
+	Resp string
 	// RespSig is the response's signature signed by the server. It is base 64
 	// encoded.
 	RespSig string
@@ -66,7 +66,7 @@ func (vdb *VspDatabase) InsertAltSignAddr(ticketHash string, data *AltSignAddrDa
 			return err
 		}
 
-		if err := bkt.Put(reqK, data.Req); err != nil {
+		if err := bkt.Put(reqK, []byte(data.Req)); err != nil {
 			return err
 		}
 
@@ -74,7 +74,7 @@ func (vdb *VspDatabase) InsertAltSignAddr(ticketHash string, data *AltSignAddrDa
 			return err
 		}
 
-		if err := bkt.Put(respK, data.Resp); err != nil {
+		if err := bkt.Put(respK, []byte(data.Resp)); err != nil {
 			return err
 		}
 		return bkt.Put(respSigK, []byte(data.RespSig))
@@ -113,9 +113,9 @@ func (vdb *VspDatabase) AltSignAddrData(ticketHash string) (*AltSignAddrData, er
 		}
 		h = &AltSignAddrData{
 			AltSignAddr: string(bkt.Get(altSignAddrK)),
-			Req:         bkt.Get(reqK),
+			Req:         string(bkt.Get(reqK)),
 			ReqSig:      string(bkt.Get(reqSigK)),
-			Resp:        bkt.Get(respK),
+			Resp:        string(bkt.Get(respK)),
 			RespSig:     string(bkt.Get(respSigK)),
 		}
 		return nil

--- a/database/altsignaddr_test.go
+++ b/database/altsignaddr_test.go
@@ -12,9 +12,9 @@ import (
 func exampleAltSignAddrData() *AltSignAddrData {
 	return &AltSignAddrData{
 		AltSignAddr: randString(35, addrCharset),
-		Req:         randBytes(1000),
+		Req:         string(randBytes(1000)),
 		ReqSig:      randString(96, sigCharset),
-		Resp:        randBytes(1000),
+		Resp:        string(randBytes(1000)),
 		RespSig:     randString(96, sigCharset),
 	}
 }

--- a/webapi/admin.go
+++ b/webapi/admin.go
@@ -38,12 +38,12 @@ type DcrdStatus struct {
 }
 
 type searchResult struct {
-	Hash           string
-	Found          bool
-	Ticket         database.Ticket
-	AltSignAddr    string
-	VoteChanges    map[uint32]database.VoteChangeRecord
-	MaxVoteChanges int
+	Hash            string
+	Found           bool
+	Ticket          database.Ticket
+	AltSignAddrData *database.AltSignAddrData
+	VoteChanges     map[uint32]database.VoteChangeRecord
+	MaxVoteChanges  int
 }
 
 func dcrdStatus(c *gin.Context) DcrdStatus {
@@ -176,19 +176,14 @@ func ticketSearch(c *gin.Context) {
 		return
 	}
 
-	altSignAddr := ""
-	if altSignAddrData != nil {
-		altSignAddr = altSignAddrData.AltSignAddr
-	}
-
 	c.HTML(http.StatusOK, "admin.html", gin.H{
 		"SearchResult": searchResult{
-			Hash:           hash,
-			Found:          found,
-			Ticket:         ticket,
-			AltSignAddr:    altSignAddr,
-			VoteChanges:    voteChanges,
-			MaxVoteChanges: cfg.MaxVoteChangeRecords,
+			Hash:            hash,
+			Found:           found,
+			Ticket:          ticket,
+			AltSignAddrData: altSignAddrData,
+			VoteChanges:     voteChanges,
+			MaxVoteChanges:  cfg.MaxVoteChangeRecords,
 		},
 		"WebApiCache":  getCache(),
 		"WebApiCfg":    cfg,

--- a/webapi/setaltsignaddr.go
+++ b/webapi/setaltsignaddr.go
@@ -111,9 +111,9 @@ func setAltSignAddr(c *gin.Context) {
 
 	data := &database.AltSignAddrData{
 		AltSignAddr: altSignAddr,
-		Req:         reqBytes,
+		Req:         string(reqBytes),
 		ReqSig:      c.GetHeader("VSP-Client-Signature"),
-		Resp:        []byte(resp),
+		Resp:        resp,
 		RespSig:     respSig,
 	}
 

--- a/webapi/setaltsignaddr_test.go
+++ b/webapi/setaltsignaddr_test.go
@@ -42,6 +42,7 @@ var (
 	maxVoteChangeRecords = 3
 )
 
+// randBytes returns a byte slice of size n filled with random bytes.
 func randBytes(n int) []byte {
 	slice := make([]byte, n)
 	if _, err := seededRand.Read(slice); err != nil {
@@ -196,9 +197,9 @@ func TestSetAltSignAddress(t *testing.T) {
 		if test.isExistingAltSignAddr {
 			data := &database.AltSignAddrData{
 				AltSignAddr: test.addr,
-				Req:         b,
+				Req:         string(b),
 				ReqSig:      reqSig,
-				Resp:        randBytes(1000),
+				Resp:        string(randBytes(1000)),
 				RespSig:     randString(96, sigCharset),
 			}
 			if err := db.InsertAltSignAddr(ticketHash, data); err != nil {
@@ -256,7 +257,7 @@ func TestSetAltSignAddress(t *testing.T) {
 			continue
 		}
 
-		if !bytes.Equal(b, altsig.Req) || altsig.ReqSig != reqSig {
+		if !bytes.Equal(b, []byte(altsig.Req)) || altsig.ReqSig != reqSig {
 			t.Fatalf("%q: expected alt sign addr data different than actual", test.name)
 		}
 	}

--- a/webapi/templates/ticket-search-result.html
+++ b/webapi/templates/ticket-search-result.html
@@ -40,14 +40,6 @@
                     </a>
                 </td>
             </tr>
-            <tr>
-                <th>Alternate Signing Address</th>
-                <td>
-                    <a href="{{ addressURL .AltSignAddr }}">
-                        {{ .AltSignAddr }}
-                    </a>
-                </td>
-            </tr>
         </table>
 
         <h1>Fee</h1>
@@ -133,6 +125,50 @@
                             <tr>
                                 <th>Response<br />Signature</th>
                                 <td>{{ $value.ResponseSignature }}</td>
+                            </tr>
+                        </table>
+                    </details>
+                    {{end}}
+                </td>
+            </tr>
+        </table>
+
+        <h1>Alternate Signing Address</h1>
+        
+        <table id="ticket-table" class="mt-2 mb-4 w-100">
+            <tr>
+                <th>Alternate Signing Address</th>
+                <td>
+            {{if .AltSignAddrData}}
+                    <a href="{{ addressURL .AltSignAddrData.AltSignAddr }}">
+                        {{ .AltSignAddrData.AltSignAddr }}
+                    </a>
+            {{end}}
+                </td>
+            </tr>
+              <tr>
+                <th>
+                    AltSignAddress Change 
+                </th>
+                <td>
+                    {{if .AltSignAddrData}}
+                    <details>
+                      <table class="my-2">
+                            <tr>
+                                <th>Request</th>
+                                <td>{{ indentJSON .AltSignAddrData.Req }}</td>
+                            </tr>
+                            <tr>
+                                <th>Request<br />Signature</th>
+                                <td>{{ .AltSignAddrData.ReqSig }}</td>
+                            </tr>
+                            <tr>
+                                <th>Response</th>
+                                <td>{{ indentJSON .AltSignAddrData.Resp }}</td>
+                            </tr>
+                            <tr>
+                                <th>Response<br />Signature</th>
+                                <td>{{ .AltSignAddrData.RespSig }}</td>
                             </tr>
                         </table>
                     </details>


### PR DESCRIPTION
Before: no req/resp data displayed.
After(with data):
![altsigndatafilled](https://user-images.githubusercontent.com/57448127/148658385-725575e7-a8cc-4460-a822-7bed3d2bda6f.PNG)
After(without data):
![emptyaltsigndata](https://user-images.githubusercontent.com/57448127/148658404-042f8878-bcb1-486a-a789-e35a609f3b01.PNG)
Closes #305 