### PR TITLE
Add alternate signing address to /ticketstatus response

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -209,7 +209,8 @@ its `feetxstatus` is `confirmed`.
       "timestamp":1590509066,
       "ticketconfirmed":true,
       "feetxstatus":"broadcast",
-      "feetxhash": "e1c02b04b5bbdae66cf8e3c88366c4918d458a2d27a26144df37f54a2bc956ac",
+      "feetxhash":"e1c02b04b5bbdae66cf8e3c88366c4918d458a2d27a26144df37f54a2bc956ac",
+      "altsignaddress":"Tsfkn6k9AoYgVZRV6ZzcgmuVSgCdJQt9JY2",
       "votechoices":{"headercommitments":"no"},
       "request": {"<Copy of request body>"}
     }

--- a/webapi/ticketstatus.go
+++ b/webapi/ticketstatus.go
@@ -34,12 +34,26 @@ func ticketStatus(c *gin.Context) {
 		return
 	}
 
+	// Get altSignAddress from database
+	altSignAddrData, err := db.AltSignAddrData(ticket.Hash)
+	if err != nil {
+		log.Errorf("%s: db.AltSignAddrData error (ticketHash=%s): %v", funcName, ticket.Hash, err)
+		sendError(errInternalError, c)
+		return
+	}
+
+	altSignAddr := ""
+	if altSignAddrData != nil {
+		altSignAddr = altSignAddrData.AltSignAddr
+	}
+
 	sendJSONResponse(ticketStatusResponse{
 		Timestamp:       time.Now().Unix(),
 		Request:         reqBytes,
 		TicketConfirmed: ticket.Confirmed,
 		FeeTxStatus:     string(ticket.FeeTxStatus),
 		FeeTxHash:       ticket.FeeTxHash,
+		AltSignAddress:  altSignAddr,
 		VoteChoices:     ticket.VoteChoices,
 	}, c)
 }

--- a/webapi/types.go
+++ b/webapi/types.go
@@ -68,6 +68,7 @@ type ticketStatusResponse struct {
 	TicketConfirmed bool              `json:"ticketconfirmed"`
 	FeeTxStatus     string            `json:"feetxstatus"`
 	FeeTxHash       string            `json:"feetxhash"`
+	AltSignAddress  string            `json:"altsignaddress"`
 	VoteChoices     map[string]string `json:"votechoices"`
 	Request         []byte            `json:"request"`
 }


### PR DESCRIPTION
This PR adds alternate signing address to /ticketstatus response.
Closes #306 