### PR TITLE
Set tspend & treasury policies.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 ISC License
 
-Copyright (c) 2020-2021 The Decred developers
+Copyright (c) 2020-2022 The Decred developers
 
 Permission to use, copy, modify, and distribute this software for any
 purpose with or without fee is hereby granted, provided that the above

--- a/background/background.go
+++ b/background/background.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2021 The Decred developers
+// Copyright (c) 2020-2022 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -244,6 +244,25 @@ func blockConnected() {
 						}
 					}
 				}
+
+				// Set tspend policy on voting wallets.
+				for tspend, policy := range ticket.TSpendPolicy {
+					err = walletClient.SetTSpendPolicy(tspend, policy, ticket.Hash)
+					if err != nil {
+						log.Errorf("%s: dcrwallet.SetTSpendPolicy failed (wallet=%s, ticketHash=%s): %v",
+							funcName, walletClient.String(), ticket.Hash, err)
+					}
+				}
+
+				// Set treasury policy on voting wallets.
+				for key, policy := range ticket.TreasuryPolicy {
+					err = walletClient.SetTreasuryPolicy(key, policy, ticket.Hash)
+					if err != nil {
+						log.Errorf("%s: dcrwallet.SetTreasuryPolicy failed (wallet=%s, ticketHash=%s): %v",
+							funcName, walletClient.String(), ticket.Hash, err)
+					}
+				}
+
 				log.Infof("%s: Ticket added to voting wallet (wallet=%s, ticketHash=%s)",
 					funcName, walletClient.String(), ticket.Hash)
 			}
@@ -557,6 +576,8 @@ func checkWalletConsistency() {
 					}
 				}
 			}
+
+			// TODO - tspend and treasury policy consistency checking.
 		}
 	}
 }

--- a/database/ticket_test.go
+++ b/database/ticket_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2021 The Decred developers
+// Copyright (c) 2020-2022 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -22,6 +22,8 @@ func exampleTicket() Ticket {
 		FeeExpiration:     4,
 		Confirmed:         false,
 		VoteChoices:       map[string]string{"AgendaID": "yes"},
+		TSpendPolicy:      map[string]string{randString(64, hexCharset): "no"},
+		TreasuryPolicy:    map[string]string{randString(66, hexCharset): "abstain"},
 		VotingWIF:         randString(53, addrCharset),
 		FeeTxHex:          randString(504, hexCharset),
 		FeeTxHash:         randString(64, hexCharset),

--- a/database/upgrade_v3.go
+++ b/database/upgrade_v3.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 The Decred developers
+// Copyright (c) 2021-2022 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -52,7 +52,22 @@ func ticketBucketUpgrade(db *bolt.DB) error {
 				return fmt.Errorf("could not create new ticket bucket: %w", err)
 			}
 
-			err = putTicketInBucket(newBkt, Ticket(ticket))
+			err = putTicketInBucket(newBkt, Ticket{
+				Hash:              ticket.Hash,
+				PurchaseHeight:    ticket.PurchaseHeight,
+				CommitmentAddress: ticket.CommitmentAddress,
+				FeeAddressIndex:   ticket.FeeAddressIndex,
+				FeeAddress:        ticket.FeeAddress,
+				FeeAmount:         ticket.FeeAmount,
+				FeeExpiration:     ticket.FeeExpiration,
+				Confirmed:         ticket.Confirmed,
+				VotingWIF:         ticket.VotingWIF,
+				VoteChoices:       ticket.VoteChoices,
+				FeeTxHex:          ticket.FeeTxHex,
+				FeeTxHash:         ticket.FeeTxHash,
+				FeeTxStatus:       ticket.FeeTxStatus,
+				Outcome:           ticket.Outcome,
+			})
 			if err != nil {
 				return fmt.Errorf("could not put new ticket in bucket: %w", err)
 			}

--- a/docs/api.md
+++ b/docs/api.md
@@ -161,7 +161,9 @@ for the specified ticket.
     "tickethash":"484a68f7148e55d05f0b64a29fe7b148572cb5272d1ce2438cf15466d347f4f4",
     "feetx":"010000000125...737b266ffb9a93",
     "votingkey":"PtWUJWhSXsM9ztPkdtH8REe91z7uoidX8dsMChJUZ2spagm7YvrNm",
-    "votechoices":{"headercommitments":"yes"}
+    "votechoices":{"headercommitments":"yes"},
+    "tspendpolicy":{"<tspend tx hash>":"yes"},
+    "treasurypolicy":{"<treasury spending key>":"no"}
     }
     ```
 
@@ -212,6 +214,8 @@ its `feetxstatus` is `confirmed`.
       "feetxhash":"e1c02b04b5bbdae66cf8e3c88366c4918d458a2d27a26144df37f54a2bc956ac",
       "altsignaddress":"Tsfkn6k9AoYgVZRV6ZzcgmuVSgCdJQt9JY2",
       "votechoices":{"headercommitments":"no"},
+      "tspendpolicy":{"<tspend tx hash>":"yes"},
+      "treasurypolicy":{"<treasury spending key>":"no"},
       "request": {"<Copy of request body>"}
     }
     ```
@@ -220,6 +224,8 @@ its `feetxstatus` is `confirmed`.
 
 Clients can update the voting preferences of their ticket at any time after
 after calling `/payfee`.
+This call can be used to update consensus, treasury spend key, and tspend voting
+preferences.
 
 - `POST /api/v3/setvotechoices`
 
@@ -229,7 +235,9 @@ after calling `/payfee`.
     {
       "timestamp":1590509066,
       "tickethash":"484a68f7148e55d05f0b64a29fe7b148572cb5272d1ce2438cf15466d347f4f4",
-      "votechoices":{"headercommitments":"no"}
+      "votechoices":{"headercommitments":"no"},
+      "tspendpolicy":{"<tspend tx hash>":"yes"},
+      "treasurypolicy":{"<treasury spending key>":"no"}
     }
     ```
 

--- a/go.mod
+++ b/go.mod
@@ -3,11 +3,12 @@ module github.com/decred/vspd
 go 1.16
 
 require (
-	decred.org/dcrwallet/v2 v2.0.0-rc3
+	decred.org/dcrwallet/v2 v2.0.0
 	github.com/decred/dcrd/blockchain/stake/v4 v4.0.0
 	github.com/decred/dcrd/blockchain/v4 v4.0.0
 	github.com/decred/dcrd/chaincfg/chainhash v1.0.3
 	github.com/decred/dcrd/chaincfg/v3 v3.1.1
+	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1
 	github.com/decred/dcrd/dcrutil/v4 v4.0.0
 	github.com/decred/dcrd/hdkeychain/v3 v3.1.0
 	github.com/decred/dcrd/rpc/jsonrpc/types/v3 v3.0.0

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
-decred.org/cspp/v2 v2.0.0-20220117153402-4f26c92d52a3/go.mod h1:USyJS44Kqxz2wT/VaNsf9iTAONegO/qKXRdLg1nvrWI=
-decred.org/dcrwallet/v2 v2.0.0-rc3 h1:xxmZndkTheyfORD16nf8fUsevR3dBHdI8hhdAUFumZE=
-decred.org/dcrwallet/v2 v2.0.0-rc3/go.mod h1:NJnnnOrPISrCt5oxrkXgTu0feCnxcLUsbqsvdXtFVBI=
+decred.org/cspp/v2 v2.0.0/go.mod h1:0shJWKTWY3LxZEWGxtbER1Y45+HVjC0WZtj4bctSzCI=
+decred.org/dcrwallet/v2 v2.0.0 h1:nOGChwR5RM4QLmbm/Krit6/eQryv/RvcpUxxmUThfKI=
+decred.org/dcrwallet/v2 v2.0.0/go.mod h1:lZXgx5OcLDaWyNWFkBekqER1gdqiVwua1w68SFC1/Nk=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412 h1:w1UutsfOrms1J05zt7ISrnJIXKzwaspym5BTKGx93EI=
 github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412/go.mod h1:WPjqKcmVOxf0XSf3YxCJs6N6AOSrOx3obionmG7T0y0=

--- a/rpc/dcrwallet.go
+++ b/rpc/dcrwallet.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Decred developers
+// Copyright (c) 2020-2022 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -218,4 +218,16 @@ func (c *WalletRPC) TicketInfo(startHeight int64) (map[string]*wallettypes.Ticke
 // from the specified block height.
 func (c *WalletRPC) RescanFrom(fromHeight int64) error {
 	return c.Call(c.ctx, "rescanwallet", nil, fromHeight)
+}
+
+// SetTreasuryPolicy sets the specified tickets voting policy for all tspends
+// published by the given treasury key.
+func (c *WalletRPC) SetTreasuryPolicy(key, policy, ticket string) error {
+	return c.Call(c.ctx, "settreasurypolicy", nil, key, policy, ticket)
+}
+
+// SetTSpendPolicy sets the specified tickets voting policy for a single tspend
+// identified by its hash.
+func (c *WalletRPC) SetTSpendPolicy(tSpend, policy, ticket string) error {
+	return c.Call(c.ctx, "settspendpolicy", nil, tSpend, policy, ticket)
 }

--- a/webapi/templates/footer.html
+++ b/webapi/templates/footer.html
@@ -15,7 +15,7 @@
 
         <div class="col-md-4 col-12 footer__credit d-flex justify-content-center align-items-center">
             <p class="py-4 m-0">
-                Decred Developers | 2020-2021
+                Decred Developers | 2020-2022
                 <br />
                 The source code is available on <a href="https://github.com/decred/vspd" target="_blank" rel="noopener noreferrer">GitHub</a>
             </p>

--- a/webapi/templates/ticket-search-result.html
+++ b/webapi/templates/ticket-search-result.html
@@ -95,6 +95,22 @@
                 </td>
             </tr>
             <tr>
+                <th>TSpend Policy</th>
+                <td>
+                    {{ range $key, $value := .Ticket.TSpendPolicy }}
+                        {{ $key }}: {{ $value }} <br />
+                    {{ end }}
+                </td>
+            </tr>
+            <tr>
+                <th>Treasury Policy</th>
+                <td>
+                    {{ range $key, $value := .Ticket.TreasuryPolicy }}
+                        {{ $key }}: {{ $value }} <br />
+                    {{ end }}
+                </td>
+            </tr>
+            <tr>
                 <th>
                     Vote Choice Changes<br />
                     <em>({{ .MaxVoteChanges }} most recent)</em>
@@ -146,14 +162,14 @@
             {{end}}
                 </td>
             </tr>
-              <tr>
+            <tr>
                 <th>
                     AltSignAddress Change 
                 </th>
                 <td>
                     {{if .AltSignAddrData}}
                     <details>
-                      <table class="my-2">
+                        <table class="my-2">
                             <tr>
                                 <th>Request</th>
                                 <td>{{ indentJSON .AltSignAddrData.Req }}</td>

--- a/webapi/ticketstatus.go
+++ b/webapi/ticketstatus.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Decred developers
+// Copyright (c) 2020-2022 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -55,5 +55,7 @@ func ticketStatus(c *gin.Context) {
 		FeeTxHash:       ticket.FeeTxHash,
 		AltSignAddress:  altSignAddr,
 		VoteChoices:     ticket.VoteChoices,
+		TreasuryPolicy:  ticket.TreasuryPolicy,
+		TSpendPolicy:    ticket.TSpendPolicy,
 	}, c)
 }

--- a/webapi/types.go
+++ b/webapi/types.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2021 The Decred developers
+// Copyright (c) 2020-2022 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -36,11 +36,13 @@ type feeAddressResponse struct {
 }
 
 type payFeeRequest struct {
-	Timestamp   int64             `json:"timestamp" binding:"required"`
-	TicketHash  string            `json:"tickethash" binding:"required"`
-	FeeTx       string            `json:"feetx" binding:"required"`
-	VotingKey   string            `json:"votingkey" binding:"required"`
-	VoteChoices map[string]string `json:"votechoices" binding:"required"`
+	Timestamp      int64             `json:"timestamp" binding:"required"`
+	TicketHash     string            `json:"tickethash" binding:"required"`
+	FeeTx          string            `json:"feetx" binding:"required"`
+	VotingKey      string            `json:"votingkey" binding:"required"`
+	VoteChoices    map[string]string `json:"votechoices" binding:"required"`
+	TSpendPolicy   map[string]string `json:"tspendpolicy" binding:"max=3"`
+	TreasuryPolicy map[string]string `json:"treasurypolicy" binding:"max=3"`
 }
 
 type payFeeResponse struct {
@@ -49,9 +51,11 @@ type payFeeResponse struct {
 }
 
 type setVoteChoicesRequest struct {
-	Timestamp   int64             `json:"timestamp" binding:"required"`
-	TicketHash  string            `json:"tickethash" binding:"required"`
-	VoteChoices map[string]string `json:"votechoices" binding:"required"`
+	Timestamp      int64             `json:"timestamp" binding:"required"`
+	TicketHash     string            `json:"tickethash" binding:"required"`
+	VoteChoices    map[string]string `json:"votechoices" binding:"required"`
+	TSpendPolicy   map[string]string `json:"tspendpolicy" binding:"max=3"`
+	TreasuryPolicy map[string]string `json:"treasurypolicy" binding:"max=3"`
 }
 
 type setVoteChoicesResponse struct {
@@ -70,6 +74,8 @@ type ticketStatusResponse struct {
 	FeeTxHash       string            `json:"feetxhash"`
 	AltSignAddress  string            `json:"altsignaddress"`
 	VoteChoices     map[string]string `json:"votechoices"`
+	TSpendPolicy    map[string]string `json:"tspendpolicy"`
+	TreasuryPolicy  map[string]string `json:"treasurypolicy"`
 	Request         []byte            `json:"request"`
 }
 


### PR DESCRIPTION
This allows both tspend and treasury policies to be set by clients on a per-ticket basis. Preferences can be set when initially registering a ticket with `/payfee`, and can be later updated using `/setvotechoices`.

Any requests which alter treasury/tspend policy will be stored in the database using the existing accountability system.

**Note:** This does not include consistency checking, it will need to be added later when dcrwallet has an RPC to retrieve policies in batches.