### PR TITLE
Support link to legacy vsp

### DIFF
--- a/config.go
+++ b/config.go
@@ -62,6 +62,7 @@ type config struct {
 	BackupInterval  time.Duration `long:"backupinterval" ini-name:"backupinterval" description:"Time period between automatic database backups. Valid time units are {s,m,h}. Minimum 30 seconds."`
 	VspClosed       bool          `long:"vspclosed" ini-name:"vspclosed" description:"Closed prevents the VSP from accepting new tickets."`
 	VspClosedMsg    string        `long:"vspclosedmsg" ini-name:"vspclosedmsg" description:"A short message displayed on the webpage and returned by the status API endpoint if vspclosed is true."`
+	LegacyURL       string        `long:"legacyurl" ini-name:"legacyurl" description:"URL to legacy VSP."`
 	AdminPass       string        `long:"adminpass" ini-name:"adminpass" description:"Password for accessing admin page."`
 	Designation     string        `long:"designation" ini-name:"designation" description:"Short name for the VSP. Customizes the logo in the top toolbar."`
 

--- a/vspd.go
+++ b/vspd.go
@@ -98,6 +98,7 @@ func run(ctx context.Context) error {
 		SupportEmail:         cfg.SupportEmail,
 		VspClosed:            cfg.VspClosed,
 		VspClosedMsg:         cfg.VspClosedMsg,
+		LegacyURL:            cfg.LegacyURL,
 		AdminPass:            cfg.AdminPass,
 		Debug:                cfg.WebServerDebug,
 		Designation:          cfg.Designation,

--- a/webapi/templates/homepage.html
+++ b/webapi/templates/homepage.html
@@ -29,6 +29,14 @@
 
         {{ template "vsp-stats" . }}
     
+        {{if .WebApiCfg.LegacyURL}}
+
+        <h1>Legacy VSP</h1>
+
+        <p>Visit <a href={{.WebApiCfg.LegacyURL}} target="_blank" rel="noopener noreferrer">{{.WebApiCfg.Designation}} legacy VSP</a> to view legacy stats.</p>
+        
+        {{end}}
+    
     </div>
 </div>
 

--- a/webapi/webapi.go
+++ b/webapi/webapi.go
@@ -33,6 +33,7 @@ type Config struct {
 	SupportEmail         string
 	VspClosed            bool
 	VspClosedMsg         string
+	LegacyURL            string
 	AdminPass            string
 	Debug                bool
 	Designation          string


### PR DESCRIPTION
This makes it possible for VSP operators establish hyperlinks with their dcrstakepool site. closes #224 
PS: @jholdstock placing a single tab would look lonely on the navigation, what do you think?
If link to legacy vsp is provided:
![legacylink](https://user-images.githubusercontent.com/57448127/153180843-40b1307f-9416-4650-a7c9-9d11ac589aef.PNG)

