### PR TITLE
Use golangci-lint GitHub action.

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,10 +14,12 @@ jobs:
           go-version: ${{ matrix.go }}
       - name: Check out source
         uses: actions/checkout@v2
-      - name: Install Linters
-        run: "curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.43.0"
       - name: Build
         run: go build ./...
       - name: Test
-        run: |
-          ./run_tests.sh
+        run: env GORACE="halt_on_error=1" go test -race ./...
+      - name: Lint
+        uses: golangci/golangci-lint-action@v2
+        with:
+          version: v1.44
+

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,16 +5,29 @@ linters:
   disable-all: true
   enable:
     - asciicheck
+    - bidichk
     - deadcode
+    - durationcheck
     - errcheck
+    - errchkjson
+    - errname
+    - exhaustive
+    - exportloopref
+    - goconst
     - gofmt
     - goimports
     - gosimple
     - govet
     - ineffassign
     - misspell
+    - nilerr
     - revive
+    - staticcheck
     - structcheck
+    - tparallel
+    - typecheck
     - unconvert
     - unparam
     - unused
+    - varcheck
+    - vetshadow

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,20 @@
+run:
+  deadline: 10m
+
+linters:
+  disable-all: true
+  enable:
+    - asciicheck
+    - deadcode
+    - errcheck
+    - gofmt
+    - goimports
+    - gosimple
+    - govet
+    - ineffassign
+    - misspell
+    - revive
+    - structcheck
+    - unconvert
+    - unparam
+    - unused

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -14,28 +14,5 @@ go version
 # run tests
 env GORACE="halt_on_error=1" go test -race ./...
 
-# set output format for linter
-if [[ -v CI ]]; then
-    OUT_FORMAT="github-actions"
-else
-    OUT_FORMAT="colored-line-number"
-fi
-
 # run linter
-golangci-lint run --disable-all --deadline=10m \
-  --out-format=$OUT_FORMAT \
-  --enable=gofmt \
-  --enable=revive \
-  --enable=govet \
-  --enable=gosimple \
-  --enable=unconvert \
-  --enable=ineffassign \
-  --enable=structcheck \
-  --enable=goimports \
-  --enable=misspell \
-  --enable=unparam \
-  --enable=deadcode \
-  --enable=unused \
-  --enable=errcheck \
-  --enable=asciicheck
-  
+golangci-lint run

--- a/webapi/setaltsignaddr_test.go
+++ b/webapi/setaltsignaddr_test.go
@@ -72,11 +72,11 @@ func TestMain(m *testing.M) {
 	ctx, cancel := context.WithCancel(context.Background())
 	err = database.CreateNew(testDb, feeXPub)
 	if err != nil {
-		panic(fmt.Errorf("error creating test database: %v", err))
+		panic(fmt.Errorf("error creating test database: %w", err))
 	}
 	db, err = database.Open(ctx, &wg, testDb, time.Hour, maxVoteChangeRecords)
 	if err != nil {
-		panic(fmt.Errorf("error opening test database: %v", err))
+		panic(fmt.Errorf("error opening test database: %w", err))
 	}
 
 	// Run tests.


### PR DESCRIPTION
- Rather than manually downloading and invoking golangci-lint, use the GitHub action provided by the developers.
- Configure golangci-lint with a config file rather than passing command line args. This enables the same config to be used locally and on CI without introducing duplication. It also allows much more flexibility in configuration than using CLI args alone.

- Also adding a couple more linters.