### PR TITLE
Minor cleanups for new helpers.

### DIFF
--- a/background/background.go
+++ b/background/background.go
@@ -379,14 +379,12 @@ func Start(shutdownCtx context.Context, wg *sync.WaitGroup, vdb *database.VspDat
 	// Run voting wallet consistency check periodically.
 	wg.Add(1)
 	go func() {
-		ticker := time.NewTicker(consistencyInterval)
 	consistencyLoop:
 		for {
 			select {
 			case <-shutdownCtx.Done():
-				ticker.Stop()
 				break consistencyLoop
-			case <-ticker.C:
+			case <-time.After(consistencyInterval):
 				checkWalletConsistency()
 			}
 		}

--- a/config.go
+++ b/config.go
@@ -18,20 +18,25 @@ import (
 	"decred.org/dcrwallet/v2/wallet/txrules"
 	"github.com/decred/dcrd/dcrutil/v4"
 	"github.com/decred/dcrd/hdkeychain/v3"
+	"github.com/decred/slog"
 	"github.com/decred/vspd/database"
 	"github.com/decred/vspd/version"
 	flags "github.com/jessevdk/go-flags"
 )
 
+const appName = "vspd"
+
 var (
 	defaultListen         = ":8800"
-	defaultLogLevel       = "debug"
+	defaultLogLevel       = slog.LevelDebug.String()
 	defaultMaxLogSize     = int64(10)
 	defaultLogsToKeep     = 20
 	defaultVSPFee         = 3.0
 	defaultNetwork        = "testnet"
-	defaultHomeDir        = dcrutil.AppDataDir("vspd", false)
-	defaultConfigFilename = "vspd.conf"
+	defaultHomeDir        = dcrutil.AppDataDir(appName, false)
+	defaultConfigFilename = fmt.Sprintf("%s.conf", appName)
+	defaultLogFilename    = fmt.Sprintf("%s.log", appName)
+	defaultDBFilename     = fmt.Sprintf("%s.db", appName)
 	defaultConfigFile     = filepath.Join(defaultHomeDir, defaultConfigFilename)
 	defaultDcrdHost       = "127.0.0.1"
 	defaultWalletHost     = "127.0.0.1"
@@ -403,11 +408,11 @@ func loadConfig() (*config, error) {
 
 	// Initialize loggers and log rotation.
 	logDir := filepath.Join(cfg.HomeDir, "logs", cfg.netParams.Name)
-	initLogRotator(filepath.Join(logDir, "vspd.log"), cfg.MaxLogSize, cfg.LogsToKeep)
+	initLogRotator(filepath.Join(logDir, defaultLogFilename), cfg.MaxLogSize, cfg.LogsToKeep)
 	setLogLevels(cfg.LogLevel)
 
 	// Set the database path
-	cfg.dbPath = filepath.Join(dataDir, "vspd.db")
+	cfg.dbPath = filepath.Join(dataDir, defaultDBFilename)
 
 	// If xpub has been provided, create a new database and exit.
 	if cfg.FeeXPub != "" {

--- a/database/database.go
+++ b/database/database.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"crypto/ed25519"
 	"crypto/rand"
-	"encoding/binary"
 	"fmt"
 	"io"
 	"net/http"
@@ -87,38 +86,6 @@ func writeHotBackupFile(db *bolt.DB) error {
 
 	log.Tracef("Database backup written to %s", backupPath)
 	return err
-}
-
-func int64ToBytes(i int64) []byte {
-	bytes := make([]byte, 8)
-	binary.LittleEndian.PutUint64(bytes, uint64(i))
-	return bytes
-}
-
-func bytesToInt64(bytes []byte) int64 {
-	return int64(binary.LittleEndian.Uint64(bytes))
-}
-
-func uint32ToBytes(i uint32) []byte {
-	bytes := make([]byte, 4)
-	binary.LittleEndian.PutUint32(bytes, i)
-	return bytes
-}
-
-func bytesToUint32(bytes []byte) uint32 {
-	return binary.LittleEndian.Uint32(bytes)
-}
-
-func bytesToBool(bytes []byte) bool {
-	return bytes[0] == 1
-}
-
-func boolToBytes(b bool) []byte {
-	if b {
-		return []byte{1}
-	}
-
-	return []byte{0}
 }
 
 // CreateNew intializes a new bbolt database with all of the necessary vspd

--- a/database/database.go
+++ b/database/database.go
@@ -202,19 +202,17 @@ func Open(ctx context.Context, shutdownWg *sync.WaitGroup, dbFile string, backup
 		return nil, fmt.Errorf("upgrade failed: %w", err)
 	}
 
-	// Start a ticker to update the backup file at the specified interval.
+	// Periodically update the database backup file.
 	shutdownWg.Add(1)
 	go func() {
-		ticker := time.NewTicker(backupInterval)
 		for {
 			select {
-			case <-ticker.C:
+			case <-time.After(backupInterval):
 				err := writeHotBackupFile(db)
 				if err != nil {
 					log.Errorf("Failed to write database backup: %v", err)
 				}
 			case <-ctx.Done():
-				ticker.Stop()
 				shutdownWg.Done()
 				return
 			}

--- a/database/helpers.go
+++ b/database/helpers.go
@@ -5,6 +5,7 @@
 package database
 
 import (
+	"encoding/binary"
 	"encoding/json"
 )
 
@@ -25,4 +26,36 @@ func bytesToStringMap(bytes []byte) (map[string]string, error) {
 	}
 
 	return stringMap, nil
+}
+
+func int64ToBytes(i int64) []byte {
+	bytes := make([]byte, 8)
+	binary.LittleEndian.PutUint64(bytes, uint64(i))
+	return bytes
+}
+
+func bytesToInt64(bytes []byte) int64 {
+	return int64(binary.LittleEndian.Uint64(bytes))
+}
+
+func uint32ToBytes(i uint32) []byte {
+	bytes := make([]byte, 4)
+	binary.LittleEndian.PutUint32(bytes, i)
+	return bytes
+}
+
+func bytesToUint32(bytes []byte) uint32 {
+	return binary.LittleEndian.Uint32(bytes)
+}
+
+func bytesToBool(bytes []byte) bool {
+	return bytes[0] == 1
+}
+
+func boolToBytes(b bool) []byte {
+	if b {
+		return []byte{1}
+	}
+
+	return []byte{0}
 }

--- a/vspd.go
+++ b/vspd.go
@@ -52,7 +52,7 @@ func run(ctx context.Context) error {
 	}
 
 	// Show version at startup.
-	log.Infof("Version %s (Go version %s %s/%s)", version.String(), runtime.Version(),
+	log.Criticalf("Version %s (Go version %s %s/%s)", version.String(), runtime.Version(),
 		runtime.GOOS, runtime.GOARCH)
 
 	if cfg.VspClosed {
@@ -62,7 +62,7 @@ func run(ctx context.Context) error {
 
 	// WaitGroup for services to signal when they have shutdown cleanly.
 	var shutdownWg sync.WaitGroup
-	defer log.Info("Shutdown complete")
+	defer log.Criticalf("Shutdown complete")
 
 	// Open database.
 	db, err := database.Open(ctx, &shutdownWg, cfg.dbPath, cfg.BackupInterval, maxVoteChangeRecords)

--- a/webapi/webapi.go
+++ b/webapi/webapi.go
@@ -159,7 +159,7 @@ func Start(ctx context.Context, requestShutdown func(), shutdownWg *sync.WaitGro
 		}
 	}()
 
-	// Use a ticker to update cached VSP stats.
+	// Periodically update cached VSP stats.
 	var refresh time.Duration
 	if s.cfg.Debug {
 		refresh = 1 * time.Second
@@ -168,14 +168,12 @@ func Start(ctx context.Context, requestShutdown func(), shutdownWg *sync.WaitGro
 	}
 	shutdownWg.Add(1)
 	go func() {
-		ticker := time.NewTicker(refresh)
 		for {
 			select {
 			case <-ctx.Done():
-				ticker.Stop()
 				shutdownWg.Done()
 				return
-			case <-ticker.C:
+			case <-time.After(refresh):
 				err := updateCache(ctx, vdb, dcrd, config.NetParams, wallets)
 				if err != nil {
 					log.Errorf("Failed to update cached VSP stats: %v", err)


### PR DESCRIPTION
Following #329
- Ensure errors are properly wrapped with `%w`
- Error strings should not starts with caps.
- Add missing params to "Bad signature" error log

Following #333 
- Move database encoding helpers.

And
- Critical log startup and shutdown - these messages should always be logged, even if log level is set to WARN or ERROR.