### PR TITLE
Remove global cache variable.

### DIFF
--- a/webapi/admin.go
+++ b/webapi/admin.go
@@ -143,7 +143,7 @@ func (s *Server) statusJSON(c *gin.Context) {
 // adminPage is the handler for "GET /admin".
 func (s *Server) adminPage(c *gin.Context) {
 	c.HTML(http.StatusOK, "admin.html", gin.H{
-		"WebApiCache":  getCache(),
+		"WebApiCache":  s.cache.getData(),
 		"WebApiCfg":    s.cfg,
 		"WalletStatus": walletStatus(c),
 		"DcrdStatus":   dcrdStatus(c),
@@ -185,7 +185,7 @@ func (s *Server) ticketSearch(c *gin.Context) {
 			VoteChanges:     voteChanges,
 			MaxVoteChanges:  s.cfg.MaxVoteChangeRecords,
 		},
-		"WebApiCache":  getCache(),
+		"WebApiCache":  s.cache.getData(),
 		"WebApiCfg":    s.cfg,
 		"WalletStatus": walletStatus(c),
 		"DcrdStatus":   dcrdStatus(c),
@@ -200,7 +200,7 @@ func (s *Server) adminLogin(c *gin.Context) {
 	if password != s.cfg.AdminPass {
 		log.Warnf("Failed login attempt from %s", c.ClientIP())
 		c.HTML(http.StatusUnauthorized, "login.html", gin.H{
-			"WebApiCache":       getCache(),
+			"WebApiCache":       s.cache.getData(),
 			"WebApiCfg":         s.cfg,
 			"IncorrectPassword": true,
 		})

--- a/webapi/cache.go
+++ b/webapi/cache.go
@@ -16,9 +16,16 @@ import (
 	"github.com/dustin/go-humanize"
 )
 
-// apiCache is used to cache values which are commonly used by the API, so
+// cache is used to store values which are commonly used by the API, so
 // repeated web requests don't repeatedly trigger DB or RPC calls.
-type apiCache struct {
+type cache struct {
+	// data is the cached data.
+	data cacheData
+	// mtx must be held to read/write cache data.
+	mtx sync.RWMutex
+}
+
+type cacheData struct {
 	UpdateTime          string
 	PubKey              string
 	DatabaseSize        string
@@ -32,31 +39,26 @@ type apiCache struct {
 	RevokedProportion   float32
 }
 
-var cacheMtx sync.RWMutex
-var cache apiCache
+func (c *cache) getData() cacheData {
+	c.mtx.RLock()
+	defer c.mtx.RUnlock()
 
-func getCache() apiCache {
-	cacheMtx.RLock()
-	defer cacheMtx.RUnlock()
-
-	return cache
+	return c.data
 }
 
-// initCache creates the struct which holds the cached VSP stats, and
-// initializes it with static values.
-func initCache(signPubKey string) {
-	cacheMtx.Lock()
-	defer cacheMtx.Unlock()
-
-	cache = apiCache{
-		PubKey: signPubKey,
+// newCache creates a new cache and initializes it with static values.
+func newCache(signPubKey string) *cache {
+	return &cache{
+		data: cacheData{
+			PubKey: signPubKey,
+		},
 	}
 }
 
-// updateCache updates the dynamic values in the cache (ticket counts and best
-// block height).
-func updateCache(ctx context.Context, db *database.VspDatabase,
-	dcrd rpc.DcrdConnect, netParams *chaincfg.Params, wallets rpc.WalletConnect) error {
+// update will use the provided database and RPC connections to update the
+// dynamic values in the cache.
+func (c *cache) update(ctx context.Context, db *database.VspDatabase,
+	dcrd rpc.DcrdConnect, wallets rpc.WalletConnect, netParams *chaincfg.Params) error {
 
 	dbSize, err := db.Size()
 	if err != nil {
@@ -92,29 +94,29 @@ func updateCache(ctx context.Context, db *database.VspDatabase,
 			len(failedConnections), len(clients))
 	}
 
-	cacheMtx.Lock()
-	defer cacheMtx.Unlock()
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
 
-	cache.UpdateTime = dateTime(time.Now().Unix())
-	cache.DatabaseSize = humanize.Bytes(dbSize)
-	cache.Voting = voting
-	cache.Voted = voted
-	cache.TotalVotingWallets = int64(len(clients) + len(failedConnections))
-	cache.VotingWalletsOnline = int64(len(clients))
-	cache.Revoked = revoked
-	cache.BlockHeight = bestBlock.Height
-	cache.NetworkProportion = float32(voting) / float32(bestBlock.PoolSize)
+	c.data.UpdateTime = dateTime(time.Now().Unix())
+	c.data.DatabaseSize = humanize.Bytes(dbSize)
+	c.data.Voting = voting
+	c.data.Voted = voted
+	c.data.TotalVotingWallets = int64(len(clients) + len(failedConnections))
+	c.data.VotingWalletsOnline = int64(len(clients))
+	c.data.Revoked = revoked
+	c.data.BlockHeight = bestBlock.Height
+	c.data.NetworkProportion = float32(voting) / float32(bestBlock.PoolSize)
 
 	// Prevent dividing by zero when pool has no voted tickets.
 	switch voted {
 	case 0:
 		if revoked == 0 {
-			cache.RevokedProportion = 0
+			c.data.RevokedProportion = 0
 		} else {
-			cache.RevokedProportion = 1
+			c.data.RevokedProportion = 1
 		}
 	default:
-		cache.RevokedProportion = float32(revoked) / float32(voted)
+		c.data.RevokedProportion = float32(revoked) / float32(voted)
 	}
 
 	return nil

--- a/webapi/homepage.go
+++ b/webapi/homepage.go
@@ -12,7 +12,7 @@ import (
 
 func (s *Server) homepage(c *gin.Context) {
 	c.HTML(http.StatusOK, "homepage.html", gin.H{
-		"WebApiCache": getCache(),
+		"WebApiCache": s.cache.getData(),
 		"WebApiCfg":   s.cfg,
 	})
 }

--- a/webapi/middleware.go
+++ b/webapi/middleware.go
@@ -59,7 +59,7 @@ func (s *Server) requireAdmin(c *gin.Context) {
 
 	if admin == nil {
 		c.HTML(http.StatusUnauthorized, "login.html", gin.H{
-			"WebApiCache": getCache(),
+			"WebApiCache": s.cache.getData(),
 			"WebApiCfg":   s.cfg,
 		})
 		c.Abort()

--- a/webapi/vspinfo.go
+++ b/webapi/vspinfo.go
@@ -13,7 +13,7 @@ import (
 
 // vspInfo is the handler for "GET /api/v3/vspinfo".
 func (s *Server) vspInfo(c *gin.Context) {
-	cachedStats := getCache()
+	cachedStats := s.cache.getData()
 	s.sendJSONResponse(vspInfoResponse{
 		APIVersions:         []int64{3},
 		Timestamp:           time.Now().Unix(),


### PR DESCRIPTION
Rather than maintaining cached data in a global variable, instantiate a cache struct and keep it in the `Server` struct.

Part of #339 