### PR TITLE
Remove global vars from background.go

### DIFF
--- a/rpc/client.go
+++ b/rpc/client.go
@@ -37,7 +37,7 @@ type client struct {
 	notifier wsrpc.Notifier
 }
 
-func setup(user, pass, addr string, cert []byte, n wsrpc.Notifier) *client {
+func setup(user, pass, addr string, cert []byte) *client {
 
 	// Create TLS options.
 	pool := x509.NewCertPool()
@@ -63,7 +63,7 @@ func setup(user, pass, addr string, cert []byte, n wsrpc.Notifier) *client {
 	var mu sync.Mutex
 	var c *wsrpc.Client
 	fullAddr := "wss://" + addr + "/ws"
-	return &client{&mu, c, fullAddr, tlsOpt, authOpt, n}
+	return &client{&mu, c, fullAddr, tlsOpt, authOpt, nil}
 }
 
 func (c *client) Close() {

--- a/rpc/dcrwallet.go
+++ b/rpc/dcrwallet.go
@@ -34,7 +34,7 @@ func SetupWallet(user, pass, addrs []string, cert [][]byte, params *chaincfg.Par
 	clients := make([]*client, len(addrs))
 
 	for i := 0; i < len(addrs); i++ {
-		clients[i] = setup(user[i], pass[i], addrs[i], cert[i], nil)
+		clients[i] = setup(user[i], pass[i], addrs[i], cert[i])
 	}
 
 	return WalletConnect{
@@ -47,6 +47,7 @@ func (w *WalletConnect) Close() {
 	for _, client := range w.clients {
 		client.Close()
 	}
+	log.Debug("dcrwallet clients closed")
 }
 
 // Clients loops over each wallet and tries to establish a connection. It
@@ -61,7 +62,7 @@ func (w *WalletConnect) Clients() ([]*WalletRPC, []string) {
 
 		c, newConnection, err := connect.dial(ctx)
 		if err != nil {
-			log.Errorf("dcrwallet connection error: %v", err)
+			log.Errorf("dcrwallet dial error: %v", err)
 			failedConnections = append(failedConnections, connect.addr)
 			continue
 		}

--- a/rpc/notifs.go
+++ b/rpc/notifs.go
@@ -1,0 +1,61 @@
+package rpc
+
+import (
+	"bytes"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/decred/dcrd/wire"
+)
+
+type blockConnectedHandler struct {
+	blockConnected chan *wire.BlockHeader
+}
+
+// Notify is called every time a notification is received from dcrd client.
+// A wsrpc.Client will never call Notify concurrently. Notify should not return
+// an error because that will cause the client to close and no further
+// notifications will be received until a new connection is established.
+func (n *blockConnectedHandler) Notify(method string, msg json.RawMessage) error {
+	if method != "blockconnected" {
+		return nil
+	}
+
+	header, err := parseBlockConnected(msg)
+	if err != nil {
+		log.Errorf("Failed to parse dcrd block notification: %v", err)
+		return nil
+	}
+
+	n.blockConnected <- header
+
+	return nil
+}
+
+func (n *blockConnectedHandler) Close() error {
+	return nil
+}
+
+// parseBlockConnected extracts the block header from a
+// blockconnected JSON-RPC notification.
+func parseBlockConnected(msg json.RawMessage) (*wire.BlockHeader, error) {
+	var notif []string
+	err := json.Unmarshal(msg, &notif)
+	if err != nil {
+		return nil, fmt.Errorf("json unmarshal error: %w", err)
+	}
+
+	if len(notif) == 0 {
+		return nil, errors.New("notification is empty")
+	}
+
+	var header wire.BlockHeader
+	err = header.Deserialize(hex.NewDecoder(bytes.NewReader([]byte(notif[0]))))
+	if err != nil {
+		return nil, fmt.Errorf("error creating block header from bytes: %w", err)
+	}
+
+	return &header, nil
+}


### PR DESCRIPTION
While removing the globals from background.go it also made sense to clean up the use of dcrd RPC clients. Previously two seperate clients were maintained, one for making RPC calls and one for receiving notifications. These clients have been unified.

More of #339 