### PR TITLE
Move vspd into cmd directory.

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -21,5 +21,5 @@ jobs:
       - name: Lint
         uses: golangci/golangci-lint-action@537aa1903e5d359d0b27dbc19ddd22c5087f3fbc #v3.2.0
         with:
-          version: v1.48.0
+          version: v1.49.0
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
-*.exe
-vspd
+./vspd.exe
+./vspd
 
 # Testing, profiling, and benchmarking artifacts
 cov.out

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 ./vspd.exe
 ./vspd
+./cmd/vspd/vspd.exe
+./cmd/vspd/vspd
 
 # Testing, profiling, and benchmarking artifacts
 cov.out

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,7 +6,6 @@ linters:
   enable:
     - asciicheck
     - bidichk
-    - deadcode
     - durationcheck
     - errcheck
     - errchkjson
@@ -23,11 +22,9 @@ linters:
     - nilerr
     - revive
     - staticcheck
-    - structcheck
     - tparallel
     - typecheck
     - unconvert
     - unparam
     - unused
-    - varcheck
     - vetshadow

--- a/cmd/vspd/background.go
+++ b/cmd/vspd/background.go
@@ -15,17 +15,16 @@ import (
 )
 
 const (
-
 	// requiredConfs is the number of confirmations required to consider a
 	// ticket purchase or a fee transaction to be final.
 	requiredConfs = 6
 )
 
-// BlockConnected is called once when vspd starts up, and once each time a
+// blockConnected is called once when vspd starts up, and once each time a
 // blockconnected notification is received from dcrd.
-func BlockConnected(dcrdRPC rpc.DcrdConnect, walletRPC rpc.WalletConnect, db *database.VspDatabase, log slog.Logger) {
+func blockConnected(dcrdRPC rpc.DcrdConnect, walletRPC rpc.WalletConnect, db *database.VspDatabase, log slog.Logger) {
 
-	const funcName = "BlockConnected"
+	const funcName = "blockConnected"
 
 	dcrdClient, _, err := dcrdRPC.Client()
 	if err != nil {
@@ -281,12 +280,12 @@ func BlockConnected(dcrdRPC rpc.DcrdConnect, walletRPC rpc.WalletConnect, db *da
 
 }
 
-// CheckWalletConsistency will retrieve all votable tickets from the database
+// checkWalletConsistency will retrieve all votable tickets from the database
 // and ensure they are all added to voting wallets with the correct vote
 // choices.
-func CheckWalletConsistency(dcrdRPC rpc.DcrdConnect, walletRPC rpc.WalletConnect, db *database.VspDatabase, log slog.Logger) {
+func checkWalletConsistency(dcrdRPC rpc.DcrdConnect, walletRPC rpc.WalletConnect, db *database.VspDatabase, log slog.Logger) {
 
-	const funcName = "CheckWalletConsistency"
+	const funcName = "checkWalletConsistency"
 
 	log.Info("Checking voting wallet consistency")
 

--- a/cmd/vspd/config.go
+++ b/cmd/vspd/config.go
@@ -388,16 +388,16 @@ func loadConfig() (*config, error) {
 	}
 
 	// Verify minimum number of voting wallets are configured.
-	if numHost < cfg.netParams.MinWallets {
+	if numHost < cfg.netParams.minWallets {
 		return nil, fmt.Errorf("minimum required voting wallets has not been met: %d < %d",
-			numHost, cfg.netParams.MinWallets)
+			numHost, cfg.netParams.minWallets)
 	}
 
 	// Add default port for the active network if there is no port specified.
 	for i := 0; i < numHost; i++ {
-		cfg.walletHosts[i] = normalizeAddress(cfg.walletHosts[i], cfg.netParams.WalletRPCServerPort)
+		cfg.walletHosts[i] = normalizeAddress(cfg.walletHosts[i], cfg.netParams.walletRPCServerPort)
 	}
-	cfg.DcrdHost = normalizeAddress(cfg.DcrdHost, cfg.netParams.DcrdRPCServerPort)
+	cfg.DcrdHost = normalizeAddress(cfg.DcrdHost, cfg.netParams.dcrdRPCServerPort)
 
 	// Create the data directory.
 	dataDir := filepath.Join(cfg.HomeDir, "data", cfg.netParams.Name)
@@ -408,7 +408,7 @@ func loadConfig() (*config, error) {
 
 	// Initialize loggers and log rotation.
 	logDir := filepath.Join(cfg.HomeDir, "logs", cfg.netParams.Name)
-	cfg.logBackend, err = NewLogBackend(logDir, appName, cfg.MaxLogSize, cfg.LogsToKeep)
+	cfg.logBackend, err = newLogBackend(logDir, appName, cfg.MaxLogSize, cfg.LogsToKeep)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize logger: %w", err)
 	}
@@ -437,7 +437,7 @@ func loadConfig() (*config, error) {
 		}
 
 		// Create new database.
-		err = database.CreateNew(cfg.dbPath, cfg.FeeXPub, cfg.Logger(" DB"))
+		err = database.CreateNew(cfg.dbPath, cfg.FeeXPub, cfg.logger(" DB"))
 		if err != nil {
 			return nil, fmt.Errorf("error creating db file %s: %w", cfg.dbPath, err)
 		}
@@ -456,7 +456,7 @@ func loadConfig() (*config, error) {
 	return &cfg, nil
 }
 
-func (cfg *config) Logger(subsystem string) slog.Logger {
+func (cfg *config) logger(subsystem string) slog.Logger {
 	log := cfg.logBackend.Logger(subsystem)
 	log.SetLevel(cfg.logLevel)
 	return log

--- a/cmd/vspd/log.go
+++ b/cmd/vspd/log.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2021 The Decred developers
+// Copyright (c) 2020-2022 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -24,7 +24,7 @@ func (lw logWriter) Write(p []byte) (n int, err error) {
 	return lw.rotator.Write(p)
 }
 
-func NewLogBackend(logDir string, appName string, maxLogSize int64, logsToKeep int) (*slog.Backend, error) {
+func newLogBackend(logDir string, appName string, maxLogSize int64, logsToKeep int) (*slog.Backend, error) {
 	err := os.MkdirAll(logDir, 0700)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create log directory: %w", err)

--- a/cmd/vspd/main.go
+++ b/cmd/vspd/main.go
@@ -46,10 +46,10 @@ func run() int {
 		return 1
 	}
 
-	log := cfg.Logger("VSP")
-	dbLog := cfg.Logger(" DB")
-	apiLog := cfg.Logger("API")
-	rpcLog := cfg.Logger("RPC")
+	log := cfg.logger("VSP")
+	dbLog := cfg.logger(" DB")
+	apiLog := cfg.logger("API")
+	rpcLog := cfg.logger("RPC")
 
 	// Create a context that is cancelled when a shutdown request is received
 	// through an interrupt signal.
@@ -107,7 +107,7 @@ func run() int {
 				return
 			case header := <-notifChan:
 				log.Debugf("Block notification %d (%s)", header.Height, header.BlockHash().String())
-				BlockConnected(dcrd, wallets, db, log)
+				blockConnected(dcrd, wallets, db, log)
 			}
 		}
 	}()
@@ -143,11 +143,11 @@ func run() int {
 
 	// Run the block connected handler now to catch up with any blocks mined
 	// while vspd was shut down.
-	BlockConnected(dcrd, wallets, db, log)
+	blockConnected(dcrd, wallets, db, log)
 
 	// Run voting wallet consistency check now to ensure all wallets are up to
 	// date.
-	CheckWalletConsistency(dcrd, wallets, db, log)
+	checkWalletConsistency(dcrd, wallets, db, log)
 
 	// Run voting wallet consistency check periodically.
 	shutdownWg.Add(1)
@@ -158,7 +158,7 @@ func run() int {
 				shutdownWg.Done()
 				return
 			case <-time.After(consistencyInterval):
-				CheckWalletConsistency(dcrd, wallets, db, log)
+				checkWalletConsistency(dcrd, wallets, db, log)
 			}
 		}
 	}()
@@ -167,7 +167,7 @@ func run() int {
 	apiCfg := webapi.Config{
 		VSPFee:               cfg.VSPFee,
 		NetParams:            cfg.netParams.Params,
-		BlockExplorerURL:     cfg.netParams.BlockExplorerURL,
+		BlockExplorerURL:     cfg.netParams.blockExplorerURL,
 		SupportEmail:         cfg.SupportEmail,
 		VspClosed:            cfg.VspClosed,
 		VspClosedMsg:         cfg.VspClosedMsg,

--- a/cmd/vspd/params.go
+++ b/cmd/vspd/params.go
@@ -10,35 +10,35 @@ import (
 
 type netParams struct {
 	*chaincfg.Params
-	DcrdRPCServerPort   string
-	WalletRPCServerPort string
-	BlockExplorerURL    string
-	// MinWallets is the minimum number of voting wallets required for a vspd
+	dcrdRPCServerPort   string
+	walletRPCServerPort string
+	blockExplorerURL    string
+	// minWallets is the minimum number of voting wallets required for a vspd
 	// deployment on this network. vspd will log an error and refuse to start if
 	// fewer wallets are configured.
-	MinWallets int
+	minWallets int
 }
 
 var mainNetParams = netParams{
 	Params:              chaincfg.MainNetParams(),
-	DcrdRPCServerPort:   "9109",
-	WalletRPCServerPort: "9110",
-	BlockExplorerURL:    "https://dcrdata.decred.org",
-	MinWallets:          3,
+	dcrdRPCServerPort:   "9109",
+	walletRPCServerPort: "9110",
+	blockExplorerURL:    "https://dcrdata.decred.org",
+	minWallets:          3,
 }
 
 var testNet3Params = netParams{
 	Params:              chaincfg.TestNet3Params(),
-	DcrdRPCServerPort:   "19109",
-	WalletRPCServerPort: "19110",
-	BlockExplorerURL:    "https://testnet.dcrdata.org",
-	MinWallets:          1,
+	dcrdRPCServerPort:   "19109",
+	walletRPCServerPort: "19110",
+	blockExplorerURL:    "https://testnet.dcrdata.org",
+	minWallets:          1,
 }
 
 var simNetParams = netParams{
 	Params:              chaincfg.SimNetParams(),
-	DcrdRPCServerPort:   "19556",
-	WalletRPCServerPort: "19557",
-	BlockExplorerURL:    "...",
-	MinWallets:          1,
+	dcrdRPCServerPort:   "19556",
+	walletRPCServerPort: "19557",
+	blockExplorerURL:    "...",
+	minWallets:          1,
 }

--- a/cmd/vspd/signal.go
+++ b/cmd/vspd/signal.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2014 The btcsuite developers
-// Copyright (c) 2021 The Decred developers
+// Copyright (c) 2021-2022 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 

--- a/cmd/vspd/signal_unix.go
+++ b/cmd/vspd/signal_unix.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2016 The btcsuite developers
-// Copyright (c) 2021 The Decred developers
+// Copyright (c) 2021-2022 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 


### PR DESCRIPTION
This is standard practise in Decred golang repos. Especially useful when multiple executables are built from a single repo.

Closes #339