### PR TITLE
Make database backups optional.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,6 @@ cov.out
 *mem.out
 /webapi/test.db
 /database/test.db
-/database/test.db-backup
 
 # Go workspace
 go.work


### PR DESCRIPTION
Periodic database backups are no longer started automatically in `database.Open()`, and the backup written by `database.Close()` can now be disabled.

Only vspd itself requires backups, they are not useful for test code or future upcoming tools such as vote-validator (#335).