### PR TITLE
Rename APIError to ErrorResponse.

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,7 +9,6 @@ linters:
     - durationcheck
     - errcheck
     - errchkjson
-    - errname
     - exhaustive
     - exportloopref
     - goconst

--- a/types/types.go
+++ b/types/types.go
@@ -4,12 +4,12 @@
 
 package types
 
-type APIError struct {
+type ErrorResponse struct {
 	Code    int64  `json:"code"`
 	Message string `json:"message"`
 }
 
-func (e APIError) Error() string { return e.Message }
+func (e ErrorResponse) Error() string { return e.Message }
 
 type VspInfoResponse struct {
 	APIVersions         []int64 `json:"apiversions"`

--- a/types/types_test.go
+++ b/types/types_test.go
@@ -19,20 +19,20 @@ func TestAPIErrorAs(t *testing.T) {
 		expectedMessage string
 	}{{
 		testName:        "BadRequest error",
-		apiError:        APIError{Message: "something went wrong", Code: int64(ErrBadRequest)},
+		apiError:        ErrorResponse{Message: "something went wrong", Code: int64(ErrBadRequest)},
 		expectedKind:    ErrBadRequest,
 		expectedMessage: "something went wrong",
 	},
 		{
 			testName:        "Unknown error",
-			apiError:        APIError{Message: "something went wrong again", Code: int64(999)},
+			apiError:        ErrorResponse{Message: "something went wrong again", Code: int64(999)},
 			expectedKind:    999,
 			expectedMessage: "something went wrong again",
 		}}
 
 	for _, test := range tests {
 		// Ensure APIError can be unwrapped from error.
-		var parsedError APIError
+		var parsedError ErrorResponse
 		if !errors.As(test.apiError, &parsedError) {
 			t.Errorf("%s: unable to unwrap error", test.testName)
 			continue

--- a/webapi/webapi.go
+++ b/webapi/webapi.go
@@ -302,7 +302,7 @@ func (s *Server) sendError(e types.ErrorCode, c *gin.Context) {
 func (s *Server) sendErrorWithMsg(msg string, e types.ErrorCode, c *gin.Context) {
 	status := e.HTTPStatus()
 
-	resp := types.APIError{
+	resp := types.ErrorResponse{
 		Code:    int64(e),
 		Message: msg,
 	}


### PR DESCRIPTION
Last commit before tagging v1.0.0 of the types module. The name ErrorResponse is consistent with all other response types.