### PR TITLE
vspd: Fix invalid default config log level.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 ISC License
 
-Copyright (c) 2020-2022 The Decred developers
+Copyright (c) 2020-2023 The Decred developers
 
 Permission to use, copy, modify, and distribute this software for any
 purpose with or without fee is hereby granted, provided that the above

--- a/cmd/vspd/config.go
+++ b/cmd/vspd/config.go
@@ -28,7 +28,7 @@ const appName = "vspd"
 
 var (
 	defaultListen         = ":8800"
-	defaultLogLevel       = slog.LevelDebug.String()
+	defaultLogLevel       = "debug"
 	defaultMaxLogSize     = int64(10)
 	defaultLogsToKeep     = 20
 	defaultVSPFee         = 3.0

--- a/webapi/templates/footer.html
+++ b/webapi/templates/footer.html
@@ -15,7 +15,7 @@
 
         <div class="col-md-4 col-12 footer__credit d-flex justify-content-center align-items-center">
             <p class="py-4 m-0">
-                Decred Developers | 2020-2022
+                Decred Developers | 2020-2023
                 <br />
                 The source code is available on <a href="https://github.com/decred/vspd" target="_blank" rel="noopener noreferrer">GitHub</a>
             </p>


### PR DESCRIPTION
slog.LevelDebug.String() returns "DBG" which is not valid per the config validation rules specified below. Hard-code "debug" instead.