### PR TITLE
client: Hard-code validation func and add extra testing.

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -7,18 +7,9 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/decred/dcrd/txscript/v4/stdaddr"
 	"github.com/decred/slog"
 	"github.com/decred/vspd/types"
 )
-
-func NoopSign(ctx context.Context, message string, address stdaddr.Address) ([]byte, error) {
-	return nil, nil
-}
-
-func NoopValidate(resp *http.Response, body []byte, serverPubkey []byte) error {
-	return nil
-}
 
 // TestErrorDetails ensures errors returned by client.do contain adequate
 // information for debugging (HTTP status and response body).
@@ -68,11 +59,9 @@ func TestErrorDetails(t *testing.T) {
 			}))
 
 			client := Client{
-				URL:      testServer.URL,
-				PubKey:   []byte("fake pubkey"),
-				Sign:     NoopSign,
-				Validate: NoopValidate,
-				Log:      slog.Disabled,
+				URL:    testServer.URL,
+				PubKey: []byte("fake pubkey"),
+				Log:    slog.Disabled,
 			}
 
 			var resp interface{}


### PR DESCRIPTION
The client previously supported overriding the default server signature validation func. This was added to facilitate testing but turns out to be unnecessary. Removing it because it makes consuming the client lib more cumbersome than it should be.

