### PR TITLE
main: Update gitignore to only ignore executables.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,18 @@
 # Executables built by this repo.
-vspd.exe
-vspd
+/cmd/vspd/vspd.exe
+/cmd/vspd/vspd
+/vspd.exe
+/vspd
 
-vote-validator.exe
-vote-validator
+/cmd/vote-validator/vote-validator.exe
+/cmd/vote-validator/vote-validator
+/vote-validator.exe
+/vote-validator
 
-v3tool.exe
-v3tool
+/cmd/v3tool/v3tool.exe
+/cmd/v3tool/v3tool
+/v3tool.exe
+/v3tool
 
 vote-validator.log
 


### PR DESCRIPTION
A line such as "v3tool" is not specific enough as it does not only ignore files named "v3tool", but also directories. This is problematic when adding new files to the directory "/cmd/v3tool/".