### PR TITLE
Hoist database integrity checks up to vspd.

### DIFF
--- a/database/database.go
+++ b/database/database.go
@@ -17,7 +17,6 @@ import (
 	"time"
 
 	"github.com/decred/slog"
-	"github.com/decred/vspd/rpc"
 	bolt "go.etcd.io/bbolt"
 )
 
@@ -404,53 +403,4 @@ func (vdb *VspDatabase) BackupDB(w http.ResponseWriter) error {
 	})
 
 	return err
-}
-
-// CheckIntegrity will ensure that all data expected to be in the database is
-// present and up to date.
-func (vdb *VspDatabase) CheckIntegrity(dcrd rpc.DcrdConnect) error {
-
-	// Ensure a purchase height is recorded for all confirmed tickets in the
-	// database. This is necessary because of an old bug which, in some
-	// circumstances, would prevent purchase height from being stored.
-
-	missing, err := vdb.GetMissingPurchaseHeight()
-	if err != nil {
-		// Cannot proceed if this fails, return.
-		return fmt.Errorf("db.GetMissingPurchaseHeight error: %w", err)
-	}
-
-	if len(missing) == 0 {
-		// Nothing to do, return.
-		return nil
-	}
-
-	vdb.log.Warnf("%d tickets are missing purchase heights", len(missing))
-
-	dcrdClient, _, err := dcrd.Client()
-	if err != nil {
-		// Cannot proceed if this fails, return.
-		return err
-	}
-
-	fixed := 0
-	for _, ticket := range missing {
-		tktTx, err := dcrdClient.GetRawTransaction(ticket.Hash)
-		if err != nil {
-			// Just log and continue, other tickets might succeed.
-			vdb.log.Errorf("Could not get raw tx for ticket %s: %v", ticket.Hash, err)
-			continue
-		}
-		ticket.PurchaseHeight = tktTx.BlockHeight
-		err = vdb.UpdateTicket(ticket)
-		if err != nil {
-			// Just log and continue, other tickets might succeed.
-			vdb.log.Errorf("Could not insert purchase height for ticket %s: %v", ticket.Hash, err)
-			continue
-		}
-		fixed++
-	}
-
-	vdb.log.Infof("Added missing purchase height to %d tickets", fixed)
-	return nil
 }


### PR DESCRIPTION
This lays the groundwork for adding new integrity checks in future. The first of which will be implementing #268, using gcs filters to update all tickets in `revoked` status to either be `missed` or `expired`.

Requires #408 and #409