### PR TITLE
database: Return explicit nil instead of err.

### DIFF
--- a/database/database.go
+++ b/database/database.go
@@ -86,7 +86,7 @@ func (vdb *VspDatabase) writeHotBackupFile() error {
 
 	vdb.log.Tracef("Database backup written to %s", backupPath)
 
-	return err
+	return nil
 }
 
 // CreateNew intializes a new bbolt database with all of the necessary vspd


### PR DESCRIPTION
No functional change because err is already checked and known to be nil, but explicitly returning nil is easier/quicker to interpret when reading.