### PR TITLE
Display expired/missed tickets on webpage

### DIFF
--- a/webapi/cache.go
+++ b/webapi/cache.go
@@ -108,16 +108,13 @@ func (c *cache) update(db *database.VspDatabase, dcrd rpc.DcrdConnect,
 	c.data.BlockHeight = bestBlock.Height
 	c.data.NetworkProportion = float32(voting) / float32(bestBlock.PoolSize)
 
-	// Prevent dividing by zero when pool has no voted tickets.
-	switch voted {
-	case 0:
-		if revoked == 0 {
-			c.data.RevokedProportion = 0
-		} else {
-			c.data.RevokedProportion = 1
-		}
-	default:
-		c.data.RevokedProportion = float32(revoked) / float32(voted)
+	total := voted + revoked
+
+	// Prevent dividing by zero when pool has no voted/revoked tickets.
+	if total == 0 {
+		c.data.RevokedProportion = 0
+	} else {
+		c.data.RevokedProportion = float32(revoked) / float32(total)
 	}
 
 	return nil

--- a/webapi/templates/homepage.html
+++ b/webapi/templates/homepage.html
@@ -18,6 +18,13 @@
             </div>
         {{ end }}
 
+        {{ if not (eq .WebApiCfg.NetParams.Name "mainnet") }}
+            <div class="alert alert-warning mb-3">
+                    This Voting Service Provider is running on testnet.
+                    Visit <a href="https://decred.org/vsp/" class="alert-link" target="_blank" rel="noopener noreferrer">decred.org</a> to find a list of mainnet VSPs.
+            </div>
+        {{ end }}
+
         <h1>VSP Overview</h1>
 
         <p class="pt-1 pb-2">A Voting Service Provider (VSP) maintains a pool of always-online voting wallets,

--- a/webapi/templates/vsp-stats.html
+++ b/webapi/templates/vsp-stats.html
@@ -13,10 +13,18 @@
     </div>
 
     <div class="col-6 col-sm-4 col-lg-2 py-3">
-        <div class="stat-title">Revoked tickets</div>
+        <div class="stat-title">Expired tickets</div>
         <div class="stat-value">
-            {{ comma .WebApiCache.Revoked }}
-            <span class="text-muted">({{ float32ToPercent .WebApiCache.RevokedProportion }})</span>
+            {{ comma .WebApiCache.Expired }}
+            <span class="text-muted">({{ float32ToPercent .WebApiCache.ExpiredProportion }})</span>
+        </div>
+    </div>
+
+    <div class="col-6 col-sm-4 col-lg-2 py-3">
+        <div class="stat-title">Missed tickets</div>
+        <div class="stat-value">
+            {{ comma .WebApiCache.Missed }}
+            <span class="text-muted">({{ float32ToPercent .WebApiCache.MissedProportion }})</span>
         </div>
     </div>
 

--- a/webapi/templates/vsp-stats.html
+++ b/webapi/templates/vsp-stats.html
@@ -26,11 +26,6 @@
     </div>
 
     <div class="col-6 col-sm-4 col-lg-2 py-3">
-        <div class="stat-title">Network</div>
-        <div class="stat-value">{{ .WebApiCfg.NetParams.Name }}</div>
-    </div>
-
-    <div class="col-6 col-sm-4 col-lg-2 py-3">
         <div class="stat-title">Network Proportion</div>
         <div class="stat-value">{{ float32ToPercent .WebApiCache.NetworkProportion }}</div>
     </div>

--- a/webapi/vspinfo.go
+++ b/webapi/vspinfo.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2022 The Decred developers
+// Copyright (c) 2020-2023 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -28,7 +28,7 @@ func (s *Server) vspInfo(c *gin.Context) {
 		Voted:               cachedStats.Voted,
 		TotalVotingWallets:  cachedStats.TotalVotingWallets,
 		VotingWalletsOnline: cachedStats.VotingWalletsOnline,
-		Revoked:             cachedStats.Revoked,
+		Revoked:             cachedStats.Expired + cachedStats.Missed,
 		BlockHeight:         cachedStats.BlockHeight,
 		NetworkProportion:   cachedStats.NetworkProportion,
 	}, c)


### PR DESCRIPTION
In order to make space for the new counters the network is no longer displayed in the stats row. It is replaced with a banner which is only shown on testnet. PR also includes a fix for a minor bug I noticed along the way.

![Screenshot from 2023-08-29 12-34-44](https://github.com/decred/vspd/assets/6762864/89f6c426-b69f-48eb-96ee-c86ae5d91722)

Contributes to #268 

