### PR TITLE
Consolidate background task timers.

### DIFF
--- a/cmd/vspd/vspd.go
+++ b/cmd/vspd/vspd.go
@@ -116,7 +116,7 @@ func (v *vspd) run() int {
 
 	// Create a context that is cancelled when a shutdown request is received
 	// through an interrupt signal.
-	shutdownCtx := shutdownListener(v.log)
+	ctx := shutdownListener(v.log)
 
 	// Run database integrity checks to ensure all data in database is present
 	// and up-to-date.
@@ -151,7 +151,7 @@ func (v *vspd) run() int {
 		MaxVoteChangeRecords: maxVoteChangeRecords,
 		VspdVersion:          version.String(),
 	}
-	err = webapi.Start(shutdownCtx, requestShutdown, &shutdownWg, v.cfg.Listen, v.db, v.cfg.logger("API"),
+	err = webapi.Start(ctx, requestShutdown, &shutdownWg, v.cfg.Listen, v.db, v.cfg.logger("API"),
 		v.dcrd, v.wallets, apiCfg)
 	if err != nil {
 		v.log.Errorf("Failed to initialize webapi: %v", err)
@@ -194,7 +194,7 @@ func (v *vspd) run() int {
 				v.blockConnected()
 
 			// Handle shutdown request.
-			case <-shutdownCtx.Done():
+			case <-ctx.Done():
 				backupTicker.Stop()
 				consistencyTicker.Stop()
 				dcrdTicker.Stop()

--- a/cmd/vspd/vspd.go
+++ b/cmd/vspd/vspd.go
@@ -118,11 +118,6 @@ func (v *vspd) run() int {
 	// through an interrupt signal.
 	shutdownCtx := shutdownListener(v.log)
 
-	// WaitGroup for services to signal when they have shutdown cleanly.
-	var shutdownWg sync.WaitGroup
-
-	v.db.WritePeriodicBackups(shutdownCtx, &shutdownWg, v.cfg.BackupInterval)
-
 	// Run database integrity checks to ensure all data in database is present
 	// and up-to-date.
 	err := v.checkDatabaseIntegrity()
@@ -139,19 +134,8 @@ func (v *vspd) run() int {
 	// date.
 	v.checkWalletConsistency()
 
-	// Run voting wallet consistency check periodically.
-	shutdownWg.Add(1)
-	go func() {
-		for {
-			select {
-			case <-shutdownCtx.Done():
-				shutdownWg.Done()
-				return
-			case <-time.After(consistencyInterval):
-				v.checkWalletConsistency()
-			}
-		}
-	}()
+	// WaitGroup for services to signal when they have shutdown cleanly.
+	var shutdownWg sync.WaitGroup
 
 	// Create and start webapi server.
 	apiCfg := webapi.Config{
@@ -176,36 +160,46 @@ func (v *vspd) run() int {
 		return 1
 	}
 
-	// Start handling blockConnected notifications from dcrd.
+	// Start all background tasks and notification handlers.
 	shutdownWg.Add(1)
 	go func() {
-		for {
-			select {
-			case <-shutdownCtx.Done():
-				shutdownWg.Done()
-				return
-			case header := <-v.blockNotifChan:
-				v.log.Debugf("Block notification %d (%s)", header.Height, header.BlockHash().String())
-				v.blockConnected()
-			}
-		}
-	}()
+		backupTicker := time.NewTicker(v.cfg.BackupInterval)
+		consistencyTicker := time.NewTicker(consistencyInterval)
+		dcrdTicker := time.NewTicker(dcrdInterval)
 
-	// Loop forever attempting ensuring a dcrd connection is available, so
-	// notifications are received.
-	shutdownWg.Add(1)
-	go func() {
 		for {
 			select {
-			case <-shutdownCtx.Done():
-				shutdownWg.Done()
-				return
-			case <-time.After(dcrdInterval):
-				// Ensure dcrd client is still connected.
+
+			// Periodically write a database backup file.
+			case <-backupTicker.C:
+				err := v.db.WriteHotBackupFile()
+				if err != nil {
+					v.log.Errorf("Failed to write database backup: %v", err)
+				}
+
+			// Run voting wallet consistency check periodically.
+			case <-consistencyTicker.C:
+				v.checkWalletConsistency()
+
+			// Ensure dcrd client is connected so notifications are received.
+			case <-dcrdTicker.C:
 				_, _, err := v.dcrd.Client()
 				if err != nil {
 					v.log.Errorf("dcrd connect error: %v", err)
 				}
+
+			// Handle blockconnected notifications from dcrd.
+			case header := <-v.blockNotifChan:
+				v.log.Debugf("Block notification %d (%s)", header.Height, header.BlockHash().String())
+				v.blockConnected()
+
+			// Handle shutdown request.
+			case <-shutdownCtx.Done():
+				backupTicker.Stop()
+				consistencyTicker.Stop()
+				dcrdTicker.Stop()
+				shutdownWg.Done()
+				return
 			}
 		}
 	}()

--- a/cmd/vspd/vspd.go
+++ b/cmd/vspd/vspd.go
@@ -34,6 +34,9 @@ const (
 
 	// consistencyInterval is the time period between wallet consistency checks.
 	consistencyInterval = 30 * time.Minute
+
+	// dcrdInterval is the time period between dcrd connection checks.
+	dcrdInterval = time.Second * 15
 )
 
 type vspd struct {
@@ -197,7 +200,7 @@ func (v *vspd) run() int {
 			case <-shutdownCtx.Done():
 				shutdownWg.Done()
 				return
-			case <-time.After(time.Second * 15):
+			case <-time.After(dcrdInterval):
 				// Ensure dcrd client is still connected.
 				_, _, err := v.dcrd.Client()
 				if err != nil {

--- a/webapi/webapi.go
+++ b/webapi/webapi.go
@@ -75,7 +75,7 @@ type Server struct {
 	signPubKey  ed25519.PublicKey
 }
 
-func Start(shutdownCtx context.Context, requestShutdown func(), shutdownWg *sync.WaitGroup,
+func Start(ctx context.Context, requestShutdown func(), shutdownWg *sync.WaitGroup,
 	listen string, vdb *database.VspDatabase, log slog.Logger, dcrd rpc.DcrdConnect,
 	wallets rpc.WalletConnect, config Config) error {
 
@@ -123,7 +123,7 @@ func Start(shutdownCtx context.Context, requestShutdown func(), shutdownWg *sync
 
 	// Create TCP listener.
 	var listenConfig net.ListenConfig
-	listener, err := listenConfig.Listen(shutdownCtx, "tcp", listen)
+	listener, err := listenConfig.Listen(ctx, "tcp", listen)
 	if err != nil {
 		return err
 	}
@@ -139,7 +139,7 @@ func Start(shutdownCtx context.Context, requestShutdown func(), shutdownWg *sync
 	shutdownWg.Add(1)
 	go func() {
 		// Wait until shutdown is signaled before shutting down.
-		<-shutdownCtx.Done()
+		<-ctx.Done()
 
 		log.Debug("Stopping webserver...")
 		// Give the webserver 5 seconds to finish what it is doing.
@@ -176,7 +176,7 @@ func Start(shutdownCtx context.Context, requestShutdown func(), shutdownWg *sync
 	go func() {
 		for {
 			select {
-			case <-shutdownCtx.Done():
+			case <-ctx.Done():
 				shutdownWg.Done()
 				return
 			case <-time.After(refresh):


### PR DESCRIPTION
Using a single select loop for background tasks removes a lot of duplicated boilerplate code and helps to simplify shutdown logic. This does reduce the amount of things which can run in parallel, but that isn't of concern for vspd. The web server still runs in its own goroutine so its responsiveness won't be affected.