### PR TITLE
Don't use RPC to determine DCP0010 status

### DIFF
--- a/internal/config/network.go
+++ b/internal/config/network.go
@@ -20,6 +20,9 @@ type Network struct {
 	// DCP0005Height is the activation height of DCP-0005 block header
 	// commitments agenda on this network.
 	DCP0005Height int64
+	// DCP0010Height is the activation height of DCP-0010 change PoW/PoS subsidy
+	// split agenda on this network.
+	DCP0010Height int64
 }
 
 var MainNet = Network{
@@ -31,6 +34,9 @@ var MainNet = Network{
 	// DCP0005Height on mainnet is block
 	// 000000000000000010815bed2c4dc431c34a859f4fc70774223dde788e95a01e.
 	DCP0005Height: 431488,
+	// DCP0010Height on mainnet is block
+	// 00000000000000002f4c6aaf0e9cb4d5a74c238d9bf8b8909e2372776c7c214c.
+	DCP0010Height: 657280,
 }
 
 var TestNet3 = Network{
@@ -42,6 +48,9 @@ var TestNet3 = Network{
 	// DCP0005Height on testnet3 is block
 	// 0000003e54421d585f4a609393a8694509af98f62b8449f245b09fe1389f8f77.
 	DCP0005Height: 323328,
+	// DCP0010Height on testnet3 is block
+	// 000000000000c7fd75f2234bbff6bb81de3a9ebbd2fdd383ae3dbc6205ffe4ff.
+	DCP0010Height: 877728,
 }
 
 var SimNet = Network{
@@ -52,12 +61,20 @@ var SimNet = Network{
 	MinWallets:          1,
 	// DCP0005Height on simnet is 1 because the agenda will always be active.
 	DCP0005Height: 1,
+	// DCP0010Height on simnet is 1 because the agenda will always be active.
+	DCP0010Height: 1,
 }
 
 // DCP5Active returns true if the DCP-0005 block header commitments agenda is
 // active on this network at the provided height, otherwise false.
 func (n *Network) DCP5Active(height int64) bool {
 	return height >= n.DCP0005Height
+}
+
+// DCP10Active returns true if the DCP-0010 change PoW/PoS subsidy split agenda
+// is active on this network at the provided height, otherwise false.
+func (n *Network) DCP10Active(height int64) bool {
+	return height >= n.DCP0010Height
 }
 
 // CurrentVoteVersion returns the most recent version in the current networks

--- a/internal/webapi/getfeeaddress.go
+++ b/internal/webapi/getfeeaddress.go
@@ -56,10 +56,7 @@ func (s *server) getCurrentFee(dcrdClient *rpc.DcrdRPC) (dcrutil.Amount, error) 
 	// is only used to calculate the fee charged for adding a ticket to the VSP.
 	const defaultMinRelayTxFee = dcrutil.Amount(1e4)
 
-	isDCP0010Active, err := dcrdClient.IsDCP0010Active()
-	if err != nil {
-		return 0, err
-	}
+	isDCP0010Active := s.cfg.Network.DCP10Active(int64(bestBlock.Height))
 
 	fee := txrules.StakePoolTicketFee(sDiff, defaultMinRelayTxFee,
 		int32(bestBlock.Height), s.cfg.VSPFee, s.cfg.Network.Params, isDCP0010Active)

--- a/rpc/dcrd.go
+++ b/rpc/dcrd.go
@@ -198,24 +198,6 @@ func (c *DcrdRPC) SendRawTransaction(txHex string) error {
 	return nil
 }
 
-// IsDCP0010Active uses getblockchaininfo RPC to determine if the DCP-0010
-// agenda has activated on the current network.
-func (c *DcrdRPC) IsDCP0010Active() (bool, error) {
-	var info dcrdtypes.GetBlockChainInfoResult
-	err := c.Call(context.TODO(), "getblockchaininfo", &info)
-	if err != nil {
-		return false, err
-	}
-
-	agenda, ok := info.Deployments[chaincfg.VoteIDChangeSubsidySplit]
-	if !ok {
-		return false, fmt.Errorf("getblockchaininfo did not return agenda %q",
-			chaincfg.VoteIDChangeSubsidySplit)
-	}
-
-	return agenda.Status == dcrdtypes.AgendaInfoStatusActive, nil
-}
-
 // NotifyBlocks uses notifyblocks RPC to request new block notifications from dcrd.
 func (c *DcrdRPC) NotifyBlocks() error {
 	return c.Call(context.TODO(), "notifyblocks", nil)


### PR DESCRIPTION
The activation heights are known for mainnet and testnet, so they can be hard-coded and RPC does not need to be used.

Requires #430 