### PR TITLE
Consider DCP0012 in VSP fee calculations. 

### DIFF
--- a/cmd/v3tool/dcrwallet.go
+++ b/cmd/v3tool/dcrwallet.go
@@ -13,7 +13,7 @@ import (
 	"fmt"
 	"strings"
 
-	wallettypes "decred.org/dcrwallet/v3/rpc/jsonrpc/types"
+	wallettypes "decred.org/dcrwallet/v4/rpc/jsonrpc/types"
 	"github.com/decred/dcrd/blockchain/stake/v5"
 	"github.com/decred/dcrd/chaincfg/v3"
 	"github.com/decred/dcrd/dcrutil/v4"

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/decred/vspd
 go 1.19
 
 require (
-	decred.org/dcrwallet/v3 v3.0.1
+	decred.org/dcrwallet/v4 v4.0.0-20230914182405-90232ed6062b
 	github.com/decred/dcrd/blockchain/stake/v5 v5.0.0
 	github.com/decred/dcrd/blockchain/standalone/v2 v2.2.0
 	github.com/decred/dcrd/chaincfg/chainhash v1.0.4

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-decred.org/dcrwallet/v3 v3.0.1 h1:+OLi+u/MvKc3Ubcnf19oyG/a5hJ/qp4OtezdiQZnLIs=
-decred.org/dcrwallet/v3 v3.0.1/go.mod h1:a+R8BZIOKVpWVPat5VZoBWNh/cnIciwcRkPtrzfS/tw=
+decred.org/dcrwallet/v4 v4.0.0-20230914182405-90232ed6062b h1:GRfSfZ1yNGFtPu8OnI5YiVrlpAvmi72bUsplBZ0Zg7o=
+decred.org/dcrwallet/v4 v4.0.0-20230914182405-90232ed6062b/go.mod h1:0+CchVf/baDYJ0tlDjtEzAFsvYcwWRm0eo1+Lf7Z1as=
 github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412 h1:w1UutsfOrms1J05zt7ISrnJIXKzwaspym5BTKGx93EI=
 github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412/go.mod h1:WPjqKcmVOxf0XSf3YxCJs6N6AOSrOx3obionmG7T0y0=
 github.com/bytedance/sonic v1.5.0/go.mod h1:ED5hyg4y6t3/9Ku1R6dU/4KyJ48DZ4jPhfY1O2AihPM=

--- a/internal/config/network.go
+++ b/internal/config/network.go
@@ -23,6 +23,9 @@ type Network struct {
 	// DCP0010Height is the activation height of DCP-0010 change PoW/PoS subsidy
 	// split agenda on this network.
 	DCP0010Height int64
+	// DCP0012Height is the activation height of DCP-0012 change PoW/PoS subsidy
+	// split R2 agenda on this network.
+	DCP0012Height int64
 }
 
 var MainNet = Network{
@@ -37,6 +40,9 @@ var MainNet = Network{
 	// DCP0010Height on mainnet is block
 	// 00000000000000002f4c6aaf0e9cb4d5a74c238d9bf8b8909e2372776c7c214c.
 	DCP0010Height: 657280,
+	// DCP0012Height on mainnet is block
+	// 071683030010299ab13f139df59dc98d637957b766e47f8da6dd5ac762f1e8c7.
+	DCP0012Height: 794368,
 }
 
 var TestNet3 = Network{
@@ -51,6 +57,9 @@ var TestNet3 = Network{
 	// DCP0010Height on testnet3 is block
 	// 000000000000c7fd75f2234bbff6bb81de3a9ebbd2fdd383ae3dbc6205ffe4ff.
 	DCP0010Height: 877728,
+	// DCP0012Height on testnet3 is block
+	// c7da7b548a2a9463dc97adb48433c4ffff18c3873f7e2ae99338a990dae039f0.
+	DCP0012Height: 1170048,
 }
 
 var SimNet = Network{
@@ -63,6 +72,8 @@ var SimNet = Network{
 	DCP0005Height: 1,
 	// DCP0010Height on simnet is 1 because the agenda will always be active.
 	DCP0010Height: 1,
+	// DCP0012Height on simnet is 1 because the agenda will always be active.
+	DCP0012Height: 1,
 }
 
 // DCP5Active returns true if the DCP-0005 block header commitments agenda is
@@ -75,6 +86,12 @@ func (n *Network) DCP5Active(height int64) bool {
 // is active on this network at the provided height, otherwise false.
 func (n *Network) DCP10Active(height int64) bool {
 	return height >= n.DCP0010Height
+}
+
+// DCP12Active returns true if the DCP-0012 change PoW/PoS subsidy split R2
+// agenda is active on this network at the provided height, otherwise false.
+func (n *Network) DCP12Active(height int64) bool {
+	return height >= n.DCP0012Height
 }
 
 // CurrentVoteVersion returns the most recent version in the current networks

--- a/internal/webapi/getfeeaddress.go
+++ b/internal/webapi/getfeeaddress.go
@@ -8,7 +8,7 @@ import (
 	"sync"
 	"time"
 
-	"decred.org/dcrwallet/v3/wallet/txrules"
+	"decred.org/dcrwallet/v4/wallet/txrules"
 	"github.com/decred/dcrd/dcrutil/v4"
 	"github.com/decred/vspd/database"
 	"github.com/decred/vspd/rpc"
@@ -56,10 +56,12 @@ func (w *WebAPI) getCurrentFee(dcrdClient *rpc.DcrdRPC) (dcrutil.Amount, error) 
 	// is only used to calculate the fee charged for adding a ticket to the VSP.
 	const defaultMinRelayTxFee = dcrutil.Amount(1e4)
 
-	isDCP0010Active := w.cfg.Network.DCP10Active(int64(bestBlock.Height))
+	height := int64(bestBlock.Height)
+	isDCP0010Active := w.cfg.Network.DCP10Active(height)
+	isDCP0012Active := w.cfg.Network.DCP12Active(height)
 
-	fee := txrules.StakePoolTicketFee(sDiff, defaultMinRelayTxFee,
-		int32(bestBlock.Height), w.cfg.VSPFee, w.cfg.Network.Params, isDCP0010Active)
+	fee := txrules.StakePoolTicketFee(sDiff, defaultMinRelayTxFee, int32(bestBlock.Height),
+		w.cfg.VSPFee, w.cfg.Network.Params, isDCP0010Active, isDCP0012Active)
 	if err != nil {
 		return 0, err
 	}

--- a/rpc/dcrwallet.go
+++ b/rpc/dcrwallet.go
@@ -8,7 +8,7 @@ import (
 	"context"
 	"fmt"
 
-	wallettypes "decred.org/dcrwallet/v3/rpc/jsonrpc/types"
+	wallettypes "decred.org/dcrwallet/v4/rpc/jsonrpc/types"
 	"github.com/decred/dcrd/chaincfg/v3"
 	dcrdtypes "github.com/decred/dcrd/rpc/jsonrpc/types/v4"
 	"github.com/decred/dcrd/wire"


### PR DESCRIPTION
Upgrade the dcrwallet dependency to pick up the new version of txrules.StakePoolTicketFee which considers the status of DCP0012 in its fee calculation.