### PR TITLE
webapi: Abort requests if web cache not ready.

### DIFF
--- a/internal/webapi/admin.go
+++ b/internal/webapi/admin.go
@@ -144,8 +144,10 @@ func (w *WebAPI) statusJSON(c *gin.Context) {
 
 // adminPage is the handler for "GET /admin".
 func (w *WebAPI) adminPage(c *gin.Context) {
+	cacheData := c.MustGet(cacheKey).(cacheData)
+
 	c.HTML(http.StatusOK, "admin.html", gin.H{
-		"WebApiCache":  w.cache.getData(),
+		"WebApiCache":  cacheData,
 		"WebApiCfg":    w.cfg,
 		"WalletStatus": w.walletStatus(c),
 		"DcrdStatus":   w.dcrdStatus(c),
@@ -155,6 +157,8 @@ func (w *WebAPI) adminPage(c *gin.Context) {
 // ticketSearch is the handler for "POST /admin/ticket". The hash param will be
 // used to retrieve a ticket from the database.
 func (w *WebAPI) ticketSearch(c *gin.Context) {
+	cacheData := c.MustGet(cacheKey).(cacheData)
+
 	hash := c.PostForm("hash")
 
 	ticket, found, err := w.db.GetTicketByHash(hash)
@@ -218,7 +222,7 @@ func (w *WebAPI) ticketSearch(c *gin.Context) {
 			VoteChanges:     voteChanges,
 			MaxVoteChanges:  w.cfg.MaxVoteChangeRecords,
 		},
-		"WebApiCache":  w.cache.getData(),
+		"WebApiCache":  cacheData,
 		"WebApiCfg":    w.cfg,
 		"WalletStatus": w.walletStatus(c),
 		"DcrdStatus":   w.dcrdStatus(c),
@@ -228,12 +232,14 @@ func (w *WebAPI) ticketSearch(c *gin.Context) {
 // adminLogin is the handler for "POST /admin". If a valid password is provided,
 // the current session will be authenticated as an admin.
 func (w *WebAPI) adminLogin(c *gin.Context) {
+	cacheData := c.MustGet(cacheKey).(cacheData)
+
 	password := c.PostForm("password")
 
 	if password != w.cfg.AdminPass {
 		w.log.Warnf("Failed login attempt from %s", c.ClientIP())
 		c.HTML(http.StatusUnauthorized, "login.html", gin.H{
-			"WebApiCache":    w.cache.getData(),
+			"WebApiCache":    cacheData,
 			"WebApiCfg":      w.cfg,
 			"FailedLoginMsg": "Incorrect password",
 		})

--- a/internal/webapi/cache.go
+++ b/internal/webapi/cache.go
@@ -30,6 +30,10 @@ type cache struct {
 }
 
 type cacheData struct {
+	// Initialized is set true after all of the below values have been set for
+	// the first time.
+	Initialized bool
+
 	UpdateTime          string
 	PubKey              string
 	DatabaseSize        string
@@ -43,6 +47,13 @@ type cacheData struct {
 	NetworkProportion   float32
 	ExpiredProportion   float32
 	MissedProportion    float32
+}
+
+func (c *cache) initialized() bool {
+	c.mtx.RLock()
+	defer c.mtx.RUnlock()
+
+	return c.data.Initialized
 }
 
 func (c *cache) getData() cacheData {
@@ -106,6 +117,7 @@ func (c *cache) update() error {
 	c.mtx.Lock()
 	defer c.mtx.Unlock()
 
+	c.data.Initialized = true
 	c.data.UpdateTime = dateTime(time.Now().Unix())
 	c.data.DatabaseSize = humanize.Bytes(dbSize)
 	c.data.Voting = voting

--- a/internal/webapi/homepage.go
+++ b/internal/webapi/homepage.go
@@ -11,8 +11,10 @@ import (
 )
 
 func (w *WebAPI) homepage(c *gin.Context) {
+	cacheData := c.MustGet(cacheKey).(cacheData)
+
 	c.HTML(http.StatusOK, "homepage.html", gin.H{
-		"WebApiCache": w.cache.getData(),
+		"WebApiCache": cacheData,
 		"WebApiCfg":   w.cfg,
 	})
 }

--- a/internal/webapi/middleware.go
+++ b/internal/webapi/middleware.go
@@ -98,11 +98,14 @@ func (w *WebAPI) withSession(store *sessions.CookieStore) gin.HandlerFunc {
 // Server Error.
 func (w *WebAPI) requireWebCache(c *gin.Context) {
 	if !w.cache.initialized() {
-		const str = "Cache is not yet initialized"
-		w.log.Errorf(str)
-		c.String(http.StatusInternalServerError, str)
-		c.Abort()
-		return
+		// Try to initialize it now.
+		err := w.cache.update()
+		if err != nil {
+			w.log.Errorf("Failed to initialize cache: %v", err)
+			c.String(http.StatusInternalServerError, "Cache is not initialized")
+			c.Abort()
+			return
+		}
 	}
 
 	c.Set(cacheKey, w.cache.getData())

--- a/internal/webapi/vspinfo.go
+++ b/internal/webapi/vspinfo.go
@@ -14,7 +14,8 @@ import (
 
 // vspInfo is the handler for "GET /api/v3/vspinfo".
 func (w *WebAPI) vspInfo(c *gin.Context) {
-	cachedStats := w.cache.getData()
+	cachedStats := c.MustGet(cacheKey).(cacheData)
+
 	w.sendJSONResponse(types.VspInfoResponse{
 		APIVersions:         []int64{3},
 		Timestamp:           time.Now().Unix(),


### PR DESCRIPTION
A new middleware aborts any requests which require the data cache if the cache is not yet initialized. An explicit error is returned so the admin will be immediately aware what has gone wrong.

Previously, webpages were rendered and JSON responses were sent with zero values, and with no indication of anything being wrong. This was sometimes difficult to notice, and even when noticed the cause was not immediately apparent.