### PR TITLE
database: Remove RWMutex protecting ticket bucket.

### DIFF
--- a/database/database.go
+++ b/database/database.go
@@ -25,8 +25,6 @@ type VspDatabase struct {
 	db                   *bolt.DB
 	maxVoteChangeRecords int
 	log                  slog.Logger
-
-	ticketsMtx sync.RWMutex
 }
 
 // The keys used in the database.


### PR DESCRIPTION
The mutex was added to the ticket bucket as a pre-emptive safety measure (#150), but the bbolt project documentation seems to indicate that it isn't necessary.

https://github.com/etcd-io/bbolt/blob/v1.3.7/README.md#transactions