### PR TITLE
webapi: Make debug warning banner more distinct. 

### DIFF
--- a/internal/webapi/templates/header.html
+++ b/internal/webapi/templates/header.html
@@ -67,7 +67,7 @@
 
             {{ if .WebApiCfg.Debug }}
                 <div class="container">
-                    <div class="alert alert-warning my-2">
+                    <div class="alert alert-danger my-2 w-100 text-center font-weight-bold">
                         Web server is running in debug mode - don't do this in production!
                     </div>
                 </div>


### PR DESCRIPTION
Give the debug banner a unique look by changing its class to "danger", and centering and bolding the text. This helps it to be more noticable when displayed near other banners

## Before
![Screenshot from 2023-09-19 11-46-14](https://github.com/decred/vspd/assets/6762864/625f200a-0515-4179-a1f4-a55330bacc64)

## After
![Screenshot from 2023-09-19 11-45-57](https://github.com/decred/vspd/assets/6762864/b8df634b-34d3-4911-87be-74a9492c96de)
