### PR TITLE
Refine logging of background processes

### DIFF
--- a/internal/vspd/update.go
+++ b/internal/vspd/update.go
@@ -322,7 +322,7 @@ func (v *Vspd) setOutcomes(ctx context.Context, dcrdClient *rpc.DcrdRPC) {
 			continue
 		}
 
-		v.log.Infof("Ticket %s %s at height %d",
-			dbTicket.Hash, dbTicket.Outcome, spentTicket.heightSpent)
+		v.log.Infof("Ticket %s at height %d (ticketHash=%s)",
+			dbTicket.Outcome, spentTicket.heightSpent, dbTicket.Hash)
 	}
 }

--- a/internal/vspd/update.go
+++ b/internal/vspd/update.go
@@ -254,7 +254,7 @@ func (v *Vspd) addToWallets(ctx context.Context, dcrdClient *rpc.DcrdRPC) {
 					}
 				}
 
-				v.log.Infof("Ticket added to voting wallet (wallet=%s, ticketHash=%s)",
+				v.log.Debugf("Ticket added to voting wallet (wallet=%s, ticketHash=%s)",
 					walletClient.String(), ticket.Hash)
 			}
 		}

--- a/internal/vspd/update.go
+++ b/internal/vspd/update.go
@@ -208,6 +208,9 @@ func (v *Vspd) addToWallets(ctx context.Context, dcrdClient *rpc.DcrdRPC) {
 					funcName, ticket.Hash, err)
 				continue
 			}
+
+			// Count how many wallets the ticket is added to for logging.
+			added := 0
 			for _, walletClient := range walletClients {
 				err = walletClient.AddTicketForVoting(ticket.VotingWIF, rawTicket.BlockHash, rawTicket.Hex)
 				if err != nil {
@@ -215,6 +218,7 @@ func (v *Vspd) addToWallets(ctx context.Context, dcrdClient *rpc.DcrdRPC) {
 						funcName, walletClient.String(), ticket.Hash, err)
 					continue
 				}
+				added++
 
 				// Set consensus vote choices on voting wallets.
 				for agenda, choice := range ticket.VoteChoices {
@@ -253,10 +257,11 @@ func (v *Vspd) addToWallets(ctx context.Context, dcrdClient *rpc.DcrdRPC) {
 							funcName, walletClient.String(), ticket.Hash, err)
 					}
 				}
-
-				v.log.Debugf("Ticket added to voting wallet (wallet=%s, ticketHash=%s)",
-					walletClient.String(), ticket.Hash)
 			}
+
+			v.log.Infof("Ticket added to %s (ticketHash=%s)",
+				pluralize(added, "voting wallet"),
+				ticket.Hash)
 		}
 	}
 }

--- a/internal/vspd/update.go
+++ b/internal/vspd/update.go
@@ -74,8 +74,8 @@ func (v *Vspd) updateUnconfirmed(ctx context.Context, dcrdClient *rpc.DcrdRPC) {
 			// which expired. Remove it from the db.
 			var e *wsrpc.Error
 			if errors.As(err, &e) && e.Code == rpc.ErrNoTxInfo {
-				v.log.Infof("%s: Removing unconfirmed ticket from db - no information available "+
-					"about transaction (ticketHash=%s)", funcName, ticket.Hash)
+				v.log.Infof("Removing unconfirmed ticket from db - no information available "+
+					"about transaction (ticketHash=%s)", ticket.Hash)
 
 				err = v.db.DeleteTicket(ticket)
 				if err != nil {
@@ -108,7 +108,7 @@ func (v *Vspd) updateUnconfirmed(ctx context.Context, dcrdClient *rpc.DcrdRPC) {
 				continue
 			}
 
-			v.log.Infof("%s: Ticket confirmed (ticketHash=%s)", funcName, ticket.Hash)
+			v.log.Infof("Ticket confirmed (ticketHash=%s)", ticket.Hash)
 		}
 	}
 }
@@ -134,8 +134,8 @@ func (v *Vspd) broadcastFees(ctx context.Context, dcrdClient *rpc.DcrdRPC) {
 				funcName, ticket.Hash, err)
 			ticket.FeeTxStatus = database.FeeError
 		} else {
-			v.log.Infof("%s: Fee tx broadcast for ticket (ticketHash=%s, feeHash=%s)",
-				funcName, ticket.Hash, ticket.FeeTxHash)
+			v.log.Infof("Fee tx broadcast for ticket (ticketHash=%s, feeHash=%s)",
+				ticket.Hash, ticket.FeeTxHash)
 			ticket.FeeTxStatus = database.FeeBroadcast
 		}
 
@@ -198,7 +198,7 @@ func (v *Vspd) addToWallets(ctx context.Context, dcrdClient *rpc.DcrdRPC) {
 					funcName, ticket.Hash, err)
 				continue
 			}
-			v.log.Infof("%s: Fee tx confirmed (ticketHash=%s)", funcName, ticket.Hash)
+			v.log.Infof("Fee tx confirmed (ticketHash=%s)", ticket.Hash)
 
 			// Add ticket to the voting wallet.
 
@@ -254,8 +254,8 @@ func (v *Vspd) addToWallets(ctx context.Context, dcrdClient *rpc.DcrdRPC) {
 					}
 				}
 
-				v.log.Infof("%s: Ticket added to voting wallet (wallet=%s, ticketHash=%s)",
-					funcName, walletClient.String(), ticket.Hash)
+				v.log.Infof("Ticket added to voting wallet (wallet=%s, ticketHash=%s)",
+					walletClient.String(), ticket.Hash)
 			}
 		}
 	}
@@ -322,7 +322,7 @@ func (v *Vspd) setOutcomes(ctx context.Context, dcrdClient *rpc.DcrdRPC) {
 			continue
 		}
 
-		v.log.Infof("%s: Ticket %s %s at height %d", funcName,
+		v.log.Infof("Ticket %s %s at height %d",
 			dbTicket.Hash, dbTicket.Outcome, spentTicket.heightSpent)
 	}
 }

--- a/internal/vspd/vspd.go
+++ b/internal/vspd/vspd.go
@@ -111,7 +111,7 @@ func (v *Vspd) Run(ctx context.Context) {
 		case <-dcrdTicker.C:
 			_, _, err := v.dcrd.Client()
 			if err != nil {
-				v.log.Errorf("dcrd connect error: %v", err)
+				v.log.Error(err)
 			}
 
 		// Run the update function every time a block connected notification is

--- a/internal/vspd/walletconsistency.go
+++ b/internal/vspd/walletconsistency.go
@@ -15,7 +15,7 @@ import (
 func (v *Vspd) checkWalletConsistency(ctx context.Context) {
 	const funcName = "checkWalletConsistency"
 
-	v.log.Info("Checking voting wallet consistency")
+	v.log.Debug("Checking voting wallet consistency")
 
 	dcrdClient, _, err := v.dcrd.Client()
 	if err != nil {

--- a/internal/vspd/walletconsistency.go
+++ b/internal/vspd/walletconsistency.go
@@ -75,8 +75,8 @@ func (v *Vspd) checkWalletConsistency(ctx context.Context) {
 				continue
 			}
 
-			v.log.Debugf("%s: Adding missing ticket (wallet=%s, ticketHash=%s)",
-				funcName, walletClient.String(), dbTicket.Hash)
+			v.log.Debugf("Adding missing ticket (wallet=%s, ticketHash=%s)",
+				walletClient.String(), dbTicket.Hash)
 
 			rawTicket, err := dcrdClient.GetRawTransaction(dbTicket.Hash)
 			if err != nil {
@@ -99,8 +99,8 @@ func (v *Vspd) checkWalletConsistency(ctx context.Context) {
 
 		// Perform a rescan if any missing tickets were added to this wallet.
 		if added {
-			v.log.Infof("%s: Performing a rescan on wallet %s (fromHeight=%d)",
-				funcName, walletClient.String(), minHeight)
+			v.log.Infof("Performing a rescan on wallet %s (fromHeight=%d)",
+				walletClient.String(), minHeight)
 			err = walletClient.RescanFrom(minHeight)
 			if err != nil {
 				v.log.Errorf("%s: dcrwallet.RescanFrom failed (wallet=%s): %v",
@@ -156,8 +156,8 @@ func (v *Vspd) checkWalletConsistency(ctx context.Context) {
 					continue
 				}
 
-				v.log.Debugf("%s: Updating incorrect consensus vote choices (wallet=%s, agenda=%s, ticketHash=%s)",
-					funcName, walletClient.String(), dbAgenda, dbTicket.Hash)
+				v.log.Debugf("Updating incorrect consensus vote choices (wallet=%s, agenda=%s, ticketHash=%s)",
+					walletClient.String(), dbAgenda, dbTicket.Hash)
 
 				// If db and wallet are not matching, update wallet with correct
 				// choice.

--- a/internal/vspd/walletconsistency.go
+++ b/internal/vspd/walletconsistency.go
@@ -75,7 +75,7 @@ func (v *Vspd) checkWalletConsistency(ctx context.Context) {
 				continue
 			}
 
-			v.log.Debugf("Adding missing ticket (wallet=%s, ticketHash=%s)",
+			v.log.Infof("Adding missing ticket (wallet=%s, ticketHash=%s)",
 				walletClient.String(), dbTicket.Hash)
 
 			rawTicket, err := dcrdClient.GetRawTransaction(dbTicket.Hash)
@@ -156,7 +156,7 @@ func (v *Vspd) checkWalletConsistency(ctx context.Context) {
 					continue
 				}
 
-				v.log.Debugf("Updating incorrect consensus vote choices (wallet=%s, agenda=%s, ticketHash=%s)",
+				v.log.Infof("Updating incorrect consensus vote choices (wallet=%s, agenda=%s, ticketHash=%s)",
 					walletClient.String(), dbAgenda, dbTicket.Hash)
 
 				// If db and wallet are not matching, update wallet with correct


### PR DESCRIPTION
Requires #444

Some tweaks to logging to reduce unnecessary spam, demote some less important messages to debug and promote some more significant ones to info.