### PR TITLE
version: Bump to 1.4.0-pre

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -18,7 +18,7 @@ const semverAlphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrst
 // Constants defining the application version number.
 const (
 	major = 1
-	minor = 3
+	minor = 4
 	patch = 0
 )
 


### PR DESCRIPTION
Release branch for v1.3 has been created, so bump master to 1.4.0-pre.