### PR TITLE
webapi: Add missed tickets to admin page.

### DIFF
--- a/database/ticket.go
+++ b/database/ticket.go
@@ -385,6 +385,13 @@ func (vdb *VspDatabase) GetMissingPurchaseHeight() (TicketList, error) {
 	})
 }
 
+// GetMissedTickets returns all tickets which have outcome == missed.
+func (vdb *VspDatabase) GetMissedTickets() (TicketList, error) {
+	return vdb.filterTickets(func(t *bolt.Bucket) bool {
+		return TicketOutcome(t.Get(outcomeK)) == Missed
+	})
+}
+
 // filterTickets accepts a filter function and returns all tickets from the
 // database which match the filter.
 func (vdb *VspDatabase) filterTickets(filter func(*bolt.Bucket) bool) (TicketList, error) {

--- a/database/ticket.go
+++ b/database/ticket.go
@@ -6,6 +6,7 @@ package database
 
 import (
 	"fmt"
+	"sort"
 	"time"
 
 	bolt "go.etcd.io/bbolt"
@@ -114,6 +115,12 @@ func (t TicketList) EarliestPurchaseHeight() int64 {
 		}
 	}
 	return oldestHeight
+}
+
+func (t TicketList) SortByPurchaseHeight() {
+	sort.Slice(t, func(i, j int) bool {
+		return t[i].PurchaseHeight > t[j].PurchaseHeight
+	})
 }
 
 func (t *Ticket) FeeExpired() bool {

--- a/internal/webapi/admin.go
+++ b/internal/webapi/admin.go
@@ -7,6 +7,7 @@ package webapi
 import (
 	"encoding/json"
 	"net/http"
+	"sort"
 
 	"github.com/decred/vspd/database"
 	"github.com/decred/vspd/rpc"
@@ -146,11 +147,24 @@ func (w *WebAPI) statusJSON(c *gin.Context) {
 func (w *WebAPI) adminPage(c *gin.Context) {
 	cacheData := c.MustGet(cacheKey).(cacheData)
 
+	missed, err := w.db.GetMissedTickets()
+	if err != nil {
+		w.log.Errorf("db.GetMissedTickets error: %v", err)
+		c.String(http.StatusInternalServerError, "Error getting missed tickets from db")
+		return
+	}
+
+	// Sort missed tickets by purchase height.
+	sort.Slice(missed, func(i, j int) bool {
+		return missed[i].PurchaseHeight > missed[j].PurchaseHeight
+	})
+
 	c.HTML(http.StatusOK, "admin.html", gin.H{
-		"WebApiCache":  cacheData,
-		"WebApiCfg":    w.cfg,
-		"WalletStatus": w.walletStatus(c),
-		"DcrdStatus":   w.dcrdStatus(c),
+		"WebApiCache":   cacheData,
+		"WebApiCfg":     w.cfg,
+		"WalletStatus":  w.walletStatus(c),
+		"DcrdStatus":    w.dcrdStatus(c),
+		"MissedTickets": missed,
 	})
 }
 
@@ -212,6 +226,18 @@ func (w *WebAPI) ticketSearch(c *gin.Context) {
 		feeTxDecoded = string(decoded)
 	}
 
+	missed, err := w.db.GetMissedTickets()
+	if err != nil {
+		w.log.Errorf("db.GetMissedTickets error: %v", err)
+		c.String(http.StatusInternalServerError, "Error getting missed tickets from db")
+		return
+	}
+
+	// Sort missed tickets by purchase height.
+	sort.Slice(missed, func(i, j int) bool {
+		return missed[i].PurchaseHeight > missed[j].PurchaseHeight
+	})
+
 	c.HTML(http.StatusOK, "admin.html", gin.H{
 		"SearchResult": searchResult{
 			Hash:            hash,
@@ -222,10 +248,11 @@ func (w *WebAPI) ticketSearch(c *gin.Context) {
 			VoteChanges:     voteChanges,
 			MaxVoteChanges:  w.cfg.MaxVoteChangeRecords,
 		},
-		"WebApiCache":  cacheData,
-		"WebApiCfg":    w.cfg,
-		"WalletStatus": w.walletStatus(c),
-		"DcrdStatus":   w.dcrdStatus(c),
+		"WebApiCache":   cacheData,
+		"WebApiCfg":     w.cfg,
+		"WalletStatus":  w.walletStatus(c),
+		"DcrdStatus":    w.dcrdStatus(c),
+		"MissedTickets": missed,
 	})
 }
 

--- a/internal/webapi/admin.go
+++ b/internal/webapi/admin.go
@@ -7,7 +7,6 @@ package webapi
 import (
 	"encoding/json"
 	"net/http"
-	"sort"
 
 	"github.com/decred/vspd/database"
 	"github.com/decred/vspd/rpc"
@@ -154,10 +153,7 @@ func (w *WebAPI) adminPage(c *gin.Context) {
 		return
 	}
 
-	// Sort missed tickets by purchase height.
-	sort.Slice(missed, func(i, j int) bool {
-		return missed[i].PurchaseHeight > missed[j].PurchaseHeight
-	})
+	missed.SortByPurchaseHeight()
 
 	c.HTML(http.StatusOK, "admin.html", gin.H{
 		"WebApiCache":   cacheData,
@@ -233,10 +229,7 @@ func (w *WebAPI) ticketSearch(c *gin.Context) {
 		return
 	}
 
-	// Sort missed tickets by purchase height.
-	sort.Slice(missed, func(i, j int) bool {
-		return missed[i].PurchaseHeight > missed[j].PurchaseHeight
-	})
+	missed.SortByPurchaseHeight()
 
 	c.HTML(http.StatusOK, "admin.html", gin.H{
 		"SearchResult": searchResult{

--- a/internal/webapi/formatting.go
+++ b/internal/webapi/formatting.go
@@ -62,3 +62,16 @@ func atomsToDCR(atoms int64) string {
 func float32ToPercent(input float32) string {
 	return fmt.Sprintf("%.2f%%", input*100)
 }
+
+// pluralize suffixes the provided noun with "s" if n is not 1, then
+// concatenates n and noun with a space between them. For example:
+//
+//	(0, "biscuit") will return "0 biscuits"
+//	(1, "biscuit") will return "1 biscuit"
+//	(3, "biscuit") will return "3 biscuits"
+func pluralize(n int, noun string) string {
+	if n != 1 {
+		noun += "s"
+	}
+	return fmt.Sprintf("%d %s", n, noun)
+}

--- a/internal/webapi/public/css/vspd.css
+++ b/internal/webapi/public/css/vspd.css
@@ -92,7 +92,7 @@ footer .code {
     }
 }
 
-.btn {
+.btn-primary, .btn-secondary {
     outline: 0;
     -webkit-box-shadow: 1px 3px 14px 0px rgba(0,0,0,0.19);
             box-shadow: 1px 3px 14px 0px rgba(0,0,0,0.19);
@@ -206,6 +206,12 @@ footer .code {
     padding-left: 40px;
 }
 
+table.missed-tickets th,
+table.missed-tickets td {
+    border: 1px solid #edeff1;
+    vertical-align: middle;
+    text-align: center;
+}
 
 .tabset > input {
     display:block; /* "enable" hidden elements in IE/edge */

--- a/internal/webapi/templates/admin.html
+++ b/internal/webapi/templates/admin.html
@@ -45,11 +45,18 @@
                         id="tabset_1_4"
                         hidden
                     >
+                    <input
+                        type="radio"
+                        name="tabset_1"
+                        id="tabset_1_5"
+                        hidden
+                    >
                     <ul>
                         <li><label for="tabset_1_1">VSP Status</label></li>
                         <li><label for="tabset_1_2">Ticket Search</label></li>
-                        <li><label for="tabset_1_3">Database</label></li>
-                        <li><label for="tabset_1_4">Logout</label></li>
+                        <li><label for="tabset_1_3">Missed Tickets</label></li>
+                        <li><label for="tabset_1_4">Database</label></li>
+                        <li><label for="tabset_1_5">Logout</label></li>
                     </ul>
                     
                     <div>
@@ -188,6 +195,31 @@
                             {{ with .SearchResult }}
                                 {{ template "ticket-search-result" . }}
                             {{ end }}
+                        </section>
+
+                        <section>
+                            <h1>{{ pluralize (len .MissedTickets) "Missed Ticket" }}</h1>
+                            {{ with .MissedTickets }}
+                            <table class="missed-tickets mx-auto">
+                                <thead>
+                                    <th>Purchase Height</th>
+                                    <th>Ticket Hash</th>
+                                </thead>
+                                <tbody>
+                                {{ range . }}
+                                    <tr>
+                                        <td>{{ .PurchaseHeight }}</td>
+                                        <td>
+                                            <form action="/admin/ticket" method="post">
+                                                <input type="hidden" name="hash" value="{{ .Hash }}">
+                                                <button class="btn btn-link p-0 code" type="submit">{{ .Hash }}</button>
+                                            </form>
+                                        </td>
+                                    </tr>
+                                {{ end }}
+                                </tbody>
+                            </table>
+                            {{ end}}
                         </section>
 
                         <section>

--- a/internal/webapi/webapi.go
+++ b/internal/webapi/webapi.go
@@ -217,6 +217,7 @@ func (w *WebAPI) router(cookieSecret []byte, dcrd rpc.DcrdConnect, wallets rpc.W
 		"atomsToDCR":       atomsToDCR,
 		"float32ToPercent": float32ToPercent,
 		"comma":            humanize.Comma,
+		"pluralize":        pluralize,
 	})
 
 	router.LoadHTMLGlob("internal/webapi/templates/*.html")


### PR DESCRIPTION
A new tab on the admin page displays a list of all tickets which were registered with the VSP but missed their votes. Clicking on the ticket hash redirects to the Ticket Search tab with the details of the missed ticket displayed.

Candidate for a 1.3.1 release.

![Screenshot from 2023-09-26 16-18-51](https://github.com/decred/vspd/assets/6762864/639062b7-81a3-4797-ae6f-87b03c63ac28)
![Screenshot from 2023-09-26 16-19-18](https://github.com/decred/vspd/assets/6762864/daef212e-291c-4185-a044-06cbcdb8d3fd)
