### PR TITLE
Downgrade dcrwallet dep to v3.

### DIFF
--- a/cmd/v3tool/dcrwallet.go
+++ b/cmd/v3tool/dcrwallet.go
@@ -13,7 +13,7 @@ import (
 	"fmt"
 	"strings"
 
-	wallettypes "decred.org/dcrwallet/v4/rpc/jsonrpc/types"
+	wallettypes "decred.org/dcrwallet/v3/rpc/jsonrpc/types"
 	"github.com/decred/dcrd/blockchain/stake/v5"
 	"github.com/decred/dcrd/chaincfg/v3"
 	"github.com/decred/dcrd/dcrutil/v4"

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/decred/vspd
 go 1.19
 
 require (
-	decred.org/dcrwallet/v4 v4.0.0-20230924083701-09bb3c2c5095
+	decred.org/dcrwallet/v3 v3.1.0
 	github.com/decred/dcrd/blockchain/stake/v5 v5.0.0
 	github.com/decred/dcrd/blockchain/standalone/v2 v2.2.0
 	github.com/decred/dcrd/chaincfg/chainhash v1.0.4

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-decred.org/dcrwallet/v4 v4.0.0-20230924083701-09bb3c2c5095 h1:Eu9ykx3/PwJGuE1Il7D57Eu1o0DdHk5Fc3WGL7l+9k4=
-decred.org/dcrwallet/v4 v4.0.0-20230924083701-09bb3c2c5095/go.mod h1:5mW+Jbpea7fDstBqhWHBs0PCOpDB8yX3VbGNhqLqoRQ=
+decred.org/dcrwallet/v3 v3.1.0 h1:JCPnF6ENtkeyWLLhyR6d6hzPAFccbbD0u2Fv2E2mA00=
+decred.org/dcrwallet/v3 v3.1.0/go.mod h1:KYWzL2R6ghBLSvB7XXU9S29QwgcqnApCvONMDJ6KCR0=
 github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412 h1:w1UutsfOrms1J05zt7ISrnJIXKzwaspym5BTKGx93EI=
 github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412/go.mod h1:WPjqKcmVOxf0XSf3YxCJs6N6AOSrOx3obionmG7T0y0=
 github.com/bytedance/sonic v1.5.0/go.mod h1:ED5hyg4y6t3/9Ku1R6dU/4KyJ48DZ4jPhfY1O2AihPM=

--- a/internal/webapi/getfeeaddress.go
+++ b/internal/webapi/getfeeaddress.go
@@ -8,7 +8,7 @@ import (
 	"sync"
 	"time"
 
-	"decred.org/dcrwallet/v4/wallet/txrules"
+	"decred.org/dcrwallet/v3/wallet/txrules"
 	"github.com/decred/dcrd/dcrutil/v4"
 	"github.com/decred/vspd/database"
 	"github.com/decred/vspd/rpc"
@@ -58,10 +58,9 @@ func (w *WebAPI) getCurrentFee(dcrdClient *rpc.DcrdRPC) (dcrutil.Amount, error) 
 
 	height := int64(bestBlock.Height)
 	isDCP0010Active := w.cfg.Network.DCP10Active(height)
-	isDCP0012Active := w.cfg.Network.DCP12Active(height)
 
 	fee := txrules.StakePoolTicketFee(sDiff, defaultMinRelayTxFee, int32(bestBlock.Height),
-		w.cfg.VSPFee, w.cfg.Network.Params, isDCP0010Active, isDCP0012Active)
+		w.cfg.VSPFee, w.cfg.Network.Params, isDCP0010Active)
 	if err != nil {
 		return 0, err
 	}

--- a/rpc/dcrwallet.go
+++ b/rpc/dcrwallet.go
@@ -8,7 +8,7 @@ import (
 	"context"
 	"fmt"
 
-	wallettypes "decred.org/dcrwallet/v4/rpc/jsonrpc/types"
+	wallettypes "decred.org/dcrwallet/v3/rpc/jsonrpc/types"
 	"github.com/decred/dcrd/chaincfg/v3"
 	dcrdtypes "github.com/decred/dcrd/rpc/jsonrpc/types/v4"
 	"github.com/decred/dcrd/wire"


### PR DESCRIPTION
**NOTE: Candidate for backporting to 1.3 release**

This downgrade changes StakePoolTicketFee back to the version which does not consider DCP-0012 activation.

This resolves an issue where Decrediton sometimes fails to pay VSP fees, caused by Decrediton and vspd independently calculating the fee amount using different versions of the algorithm.

Releasing the new algorithm will need to be more carefully coordinated, potentially requiring both client and server sides to be updated in sync.

