### PR TITLE
Add docs for listing on decred.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ requests, and a number of remote servers which host voting wallets. For more
 information about deploying vspd, check out
 [deployment.md](./docs/deployment.md).
 
+The process for listing a new VSP on [decred.org](https://decred.org/vsp/), and
+consequently in Decrediton, is detailed in [listing.md](./docs/listing.md).
+
 ## Development
 
 ### Test Harness

--- a/README.md
+++ b/README.md
@@ -5,8 +5,6 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/decred/vspd)](https://goreportcard.com/report/github.com/decred/vspd)
 [![Release](https://img.shields.io/github/release/decred/vspd.svg?style=flat-square)](https://github.com/decred/vspd/releases/latest)
 
-## Overview
-
 <img src="./docs/img/stakey.png" align="right" />
 
 [First announced in 2020](https://blog.decred.org/2020/06/02/A-More-Private-Way-to-Stake/),

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -4,6 +4,9 @@ This guide is deliberately written at a high level and with minimal details
 because it is assumed that VSP operators will already have a level of
 familiarity with Decred software and a level of sysadmin experience.
 
+A vspd deployment consists of a single front-end server which handles web
+requests, and a number of remote servers which host voting wallets.
+
 ```mermaid
 %%{init:{
     "theme": "neutral",

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -226,5 +226,4 @@ into all of the voting wallets.
 ## Listing on decred.org
 
 The process for listing a new VSP on [decred.org](https://decred.org/vsp/), and
-consequently in Decrediton, is detailed at
-[docs.decred.org](https://docs.decred.org/advanced/operating-a-vsp/).
+consequently in Decrediton, is detailed in [listing.md](./listing.md).

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -41,7 +41,7 @@ web(Internet<br />Traffic) ---> nginx
 
 ## Prerequisites
 
-### Build from source
+### Build from Source
 
 Compiled binaries are not provided for vspd - VSP operators are expected to
 build vspd from source.
@@ -51,7 +51,7 @@ branches.
 Neither vspd nor its dependencies (dcrd/dcrwallet) should be built from master
 when handling mainnet tickets.
 
-### Fee wallet
+### Fee Wallet
 
 A wallet should be created to collect VSP fees. Ideally this would be a cold
 wallet which is not used for any other purpose, and it should be completely

--- a/docs/listing.md
+++ b/docs/listing.md
@@ -1,44 +1,38 @@
-# Operating a Voting Service Provider (VSP)
+# Listing a VSP on decred.org
 
----
-
-## Overview
-
-VSPs are a key part of the Decred infrastructure which make participating in proof-of-stake much more accessible for the average user. It is desirable to increase the number of operating VSPs in order to promote decentralization, improve the stability of the Decred network, and give stakeholders more choice.
-
-This is a high level guide of how to set up a VSP, and the steps required to list a VSP on [decred.org](https://decred.org/vsp) and in Decrediton wallet. The guide is deliberately written at a high level and with minimal details because a level of system admin experience is assumed for VSP operators.
-
----
+Public VSP servers are a key part of the Decred infrastructure as they make
+Proof-of-Stake far more accessible for the average user.
+It is therefore desirable to increase the number of public VSPs listed in
+Decrediton and on [decred.org](https://decred.org/vsp) in order to promote
+decentralization and improve the stability of the Decred network.
 
 ## Operator Requirements
 
-* Familiarity with system administration work on Linux, e.g. configuring and running nginx, ssh, IPSec, duplicity, monit
-* Familiarity with compiling from source, setting up and maintaining `dcrd` and `dcrwallet`
-* Ability to effectively communicate in English
-* Willingness to stay in touch with the Decred community for important news and updates
-* Availability to update VSP binaries when new releases are produced
-* Operators should ideally be pairs of individuals or larger groups, e.g. corporate entities, so that the unavailability of a single person does not lead to extended outages in their absence
+* Willingness to stay in touch with the Decred community for important news and
+  updates. A private channel on [Matrix](https://chat.decred.org) exists for
+  this purpose.
+* Availability to update VSP binaries when new releases are produced.
+* Operators should ideally be pairs of individuals or larger groups, so that the
+  unavailability of a single person does not lead to extended outages in their
+  absence.
+* Ability to effectively communicate in English.
 
----
+## Deployment Requirements
 
-## VSP Requirements
-
-There are several requirements for the VSP configuration:
-
-* At least one machine to host the web front end, handling web connections from VSP users.
-* At least three machines to host voting wallets. Necessary because at least one voting wallet needs to be connected to the network and ready to vote at any time.
-* Each voting wallet should be connected to a dedicated local instance of `dcrd`.
-* The physical or virtual machines used to host the configuration must be spread across 3 or more physical locations.
-* More specifically, voting wallets must be in 3+ physically separate locations.
-* The web frontend must have an IP that is distinct from those of the voting wallets, and is ideally located in another physical location.
-* Source code for the VSP is available [on GitHub](https://github.com/decred/vspd) and binaries must be compiled from source.
-* The VSP must be run on testnet for 1 week to confirm it is working properly. Uptime and number of votes made versus missed will be checked.
-* The VSP must be run on mainnet in test mode (no public access) until a VSP operator demonstrates they have successfully voted 1 ticket of their own using the VSP.
-* The operator must have an adequate monitoring solution in place, ideally alerting on server downtime and application error logging.
-
----
+* At least one machine dedicated to hosting the web front end, handling web
+  connections from VSP users.
+* At least three dedicated machines hosting voting wallets and a local instance
+  of dcrd.
+* The machines used to host the voting wallets must be spread across 3 or more
+  physically separate locations.
+* The VSP must be run on testnet for 1 week to confirm it is working properly.
+  Uptime and number of votes made versus missed will be checked.
+* The VSP must be run on mainnet in test mode (no public access) until a VSP
+  operator demonstrates they have successfully voted 1 ticket of their own using
+  the VSP.
+* The operator must have an adequate monitoring solution in place, ideally
+  alerting on server downtime and application error logging.
 
 ## Further Information
 
-More detailed instructions on how to setup a VSP can be found on GitHub in the [vspd repo](https://github.com/decred/vspd).
 For further support you can contact the [Decred community](https://decred.org/community).

--- a/docs/listing.md
+++ b/docs/listing.md
@@ -1,0 +1,44 @@
+# Operating a Voting Service Provider (VSP)
+
+---
+
+## Overview
+
+VSPs are a key part of the Decred infrastructure which make participating in proof-of-stake much more accessible for the average user. It is desirable to increase the number of operating VSPs in order to promote decentralization, improve the stability of the Decred network, and give stakeholders more choice.
+
+This is a high level guide of how to set up a VSP, and the steps required to list a VSP on [decred.org](https://decred.org/vsp) and in Decrediton wallet. The guide is deliberately written at a high level and with minimal details because a level of system admin experience is assumed for VSP operators.
+
+---
+
+## Operator Requirements
+
+* Familiarity with system administration work on Linux, e.g. configuring and running nginx, ssh, IPSec, duplicity, monit
+* Familiarity with compiling from source, setting up and maintaining `dcrd` and `dcrwallet`
+* Ability to effectively communicate in English
+* Willingness to stay in touch with the Decred community for important news and updates
+* Availability to update VSP binaries when new releases are produced
+* Operators should ideally be pairs of individuals or larger groups, e.g. corporate entities, so that the unavailability of a single person does not lead to extended outages in their absence
+
+---
+
+## VSP Requirements
+
+There are several requirements for the VSP configuration:
+
+* At least one machine to host the web front end, handling web connections from VSP users.
+* At least three machines to host voting wallets. Necessary because at least one voting wallet needs to be connected to the network and ready to vote at any time.
+* Each voting wallet should be connected to a dedicated local instance of `dcrd`.
+* The physical or virtual machines used to host the configuration must be spread across 3 or more physical locations.
+* More specifically, voting wallets must be in 3+ physically separate locations.
+* The web frontend must have an IP that is distinct from those of the voting wallets, and is ideally located in another physical location.
+* Source code for the VSP is available [on GitHub](https://github.com/decred/vspd) and binaries must be compiled from source.
+* The VSP must be run on testnet for 1 week to confirm it is working properly. Uptime and number of votes made versus missed will be checked.
+* The VSP must be run on mainnet in test mode (no public access) until a VSP operator demonstrates they have successfully voted 1 ticket of their own using the VSP.
+* The operator must have an adequate monitoring solution in place, ideally alerting on server downtime and application error logging.
+
+---
+
+## Further Information
+
+More detailed instructions on how to setup a VSP can be found on GitHub in the [vspd repo](https://github.com/decred/vspd).
+For further support you can contact the [Decred community](https://decred.org/community).

--- a/docs/listing.md
+++ b/docs/listing.md
@@ -8,6 +8,9 @@ decentralization and improve the stability of the Decred network.
 
 ## Operator Requirements
 
+* Familiarity with system administration work on Linux.
+* Ability to compile from source, setting up and maintaining `dcrd` and
+  `dcrwallet`.
 * Willingness to stay in touch with the Decred community for important news and
   updates. A private channel on [Matrix](https://chat.decred.org) exists for
   this purpose.
@@ -25,6 +28,8 @@ decentralization and improve the stability of the Decred network.
   of dcrd.
 * The machines used to host the voting wallets must be spread across 3 or more
   physically separate locations.
+* The web frontend must have an IP that is distinct from those of the voting
+  wallets, and is ideally located in another physical location.
 * The VSP must be run on testnet for 1 week to confirm it is working properly.
   Uptime and number of votes made versus missed will be checked.
 * The VSP must be run on mainnet in test mode (no public access) until a VSP


### PR DESCRIPTION
This PR consolidates all VSP documentation into this repo. The process for listing a VSP is not really reading for a general user, so does not really belong on docs.decred.org.

