### PR TITLE
multi: Explicitly handle help requests.

### DIFF
--- a/cmd/vote-validator/main.go
+++ b/cmd/vote-validator/main.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2023 The Decred developers
+// Copyright (c) 2022-2024 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -48,15 +48,14 @@ func main() {
 }
 
 func run() int {
-	// Load config, display help if requested.
+	// If command line options are requesting help, write it to stdout and exit.
+	if config.WriteHelp(&cfg) {
+		return 0
+	}
+
+	// Parse command line options.
 	_, err := flags.Parse(&cfg)
 	if err != nil {
-		var e *flags.Error
-		if errors.As(err, &e) {
-			if e.Type == flags.ErrHelp {
-				return 0
-			}
-		}
 		return 1
 	}
 

--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -1,0 +1,19 @@
+// Copyright (c) 2024 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package config
+
+import (
+	"github.com/jessevdk/go-flags"
+)
+
+// WriteHelp will write the application help to stdout if it has been requested
+// via command line options. Only the help option is evaluated, any invalid
+// options are ignored. The return value indicates whether the help message was
+// printed or not.
+func WriteHelp(cfg interface{}) bool {
+	helpOpts := flags.Options(flags.HelpFlag | flags.PrintErrors | flags.IgnoreUnknown)
+	_, err := flags.NewParser(cfg, helpOpts).Parse()
+	return flags.WroteHelp(err)
+}


### PR DESCRIPTION
Checking for --help as an explicit step before parsing any other configs makes the code more intuitive by removing a convoluted bit of error handling, which happened to be unnecessarily duplicated in three places.

Moving it to a function in the internal package makes it reusable by multiple binaries.

This also enables the IgnoreUnknown option to be used whilst parsing for help, which ensures the presence of --help will always result in the help message being printed. This fixes a minor inconsistency where the help message would be printed if the flag was placed before an invalid config, but placing it after would cause an invalid config error to be written instead. For example, `vspd --help --fakeflag` vs `vspd --fakeflag --help`.