### PR TITLE
config: Deprecate --configfile.

### DIFF
--- a/cmd/vspd/main.go
+++ b/cmd/vspd/main.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2023 The Decred developers
+// Copyright (c) 2020-2024 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -55,13 +55,19 @@ func run() int {
 
 	if cfg.network == &config.MainNet && version.IsPreRelease() {
 		log.Warnf("")
-		log.Warnf("\tWARNING: This is a pre-release version of vspd which should not be used on mainnet.")
+		log.Warnf("\tWARNING: This is a pre-release version of vspd which should not be used on mainnet")
 		log.Warnf("")
 	}
 
 	if cfg.VspClosed {
 		log.Warnf("")
-		log.Warnf("\tWARNING: Config --vspclosed is set. This will prevent vspd from accepting new tickets.")
+		log.Warnf("\tWARNING: Config --vspclosed is set. This will prevent vspd from accepting new tickets")
+		log.Warnf("")
+	}
+
+	if cfg.ConfigFile != "" {
+		log.Warnf("")
+		log.Warnf("\tWARNING: Config --configfile is set. This is a deprecated option which has no effect and will be removed in a future release")
 		log.Warnf("")
 	}
 

--- a/harness.sh
+++ b/harness.sh
@@ -170,10 +170,10 @@ EOF
 tmux new-window -t $TMUX_SESSION -n "vspd"
 
 echo "Creating vspd database"
-tmux send-keys "vspd --configfile=${HARNESS_ROOT}/vspd/vspd.conf --homedir=${HARNESS_ROOT}/vspd --feexpub=${VSPD_FEE_XPUB}" C-m 
+tmux send-keys "vspd --homedir=${HARNESS_ROOT}/vspd --feexpub=${VSPD_FEE_XPUB}" C-m 
 sleep 3 # wait for database creation and ensure dcrwallet rpc listeners are started
 echo "Starting vspd"
-tmux send-keys "vspd --configfile=${HARNESS_ROOT}/vspd/vspd.conf --homedir=${HARNESS_ROOT}/vspd" C-m 
+tmux send-keys "vspd --homedir=${HARNESS_ROOT}/vspd" C-m 
 
 #################################################
 # All done - attach to tmux session.


### PR DESCRIPTION
This removes the --configfile option from vspd. It introduced quite a few weird edge cases (and a fair bit of code to deal with them) but afaik nobody actually used it. Note that the --homedir option stays, so it is still possible to run vspd with config in a non-default location if required.