### PR TITLE
vspd: Move config to internal package.

### DIFF
--- a/cmd/vspd/main.go
+++ b/cmd/vspd/main.go
@@ -118,14 +118,14 @@ func run() int {
 
 	// Create RPC client for local dcrd instance (used for broadcasting and
 	// checking the status of fee transactions).
-	dUser, dPass, dHost, dCert := cfg.DcrdDetails()
-	dcrd := rpc.SetupDcrd(dUser, dPass, dHost, dCert, network.Params, rpcLog, blockNotifChan)
+	dd := cfg.DcrdDetails()
+	dcrd := rpc.SetupDcrd(dd.User, dd.Password, dd.Host, dd.Cert, network.Params, rpcLog, blockNotifChan)
 
 	defer dcrd.Close()
 
 	// Create RPC client for remote dcrwallet instances (used for voting).
-	wUsers, wPasswords, wHosts, wCerts := cfg.WalletDetails()
-	wallets := rpc.SetupWallet(wUsers, wPasswords, wHosts, wCerts, network.Params, rpcLog)
+	wd := cfg.WalletDetails()
+	wallets := rpc.SetupWallet(wd.Users, wd.Passwords, wd.Hosts, wd.Certs, network.Params, rpcLog)
 	defer wallets.Close()
 
 	// Create webapi server.

--- a/cmd/vspd/main.go
+++ b/cmd/vspd/main.go
@@ -37,7 +37,7 @@ func main() {
 // initLogging uses the provided vspd config to create a logging backend, and
 // returns a function which can be used to create ready-to-use subsystem
 // loggers.
-func initLogging(cfg *vspdConfig) (func(subsystem string) slog.Logger, error) {
+func initLogging(cfg *vspd.Config) (func(subsystem string) slog.Logger, error) {
 	backend, err := newLogBackend(cfg.LogDir(), "vspd", cfg.MaxLogSize, cfg.LogsToKeep)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize logger: %w", err)
@@ -60,7 +60,7 @@ func initLogging(cfg *vspdConfig) (func(subsystem string) slog.Logger, error) {
 // fact that deferred functions do not run when os.Exit() is called.
 func run() int {
 	// Load config file and parse CLI args.
-	cfg, err := loadConfig()
+	cfg, err := vspd.LoadConfig()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "loadConfig error: %v\n", err)
 		return 1

--- a/internal/vspd/config.go
+++ b/internal/vspd/config.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
-package main
+package vspd
 
 import (
 	"errors"
@@ -29,8 +29,8 @@ const (
 	dbFilename     = "vspd.db"
 )
 
-// vspdConfig defines the configuration options for the vspd process.
-type vspdConfig struct {
+// Config defines the configuration options for the vspd process.
+type Config struct {
 	Listen          string        `long:"listen" ini-name:"listen" description:"The ip:port to listen for API requests."`
 	LogLevel        string        `long:"loglevel" ini-name:"loglevel" description:"Logging level." choice:"trace" choice:"debug" choice:"info" choice:"warn" choice:"error" choice:"critical"`
 	MaxLogSize      int64         `long:"maxlogsize" ini-name:"maxlogsize" description:"File size threshold for log file rotation (MB)."`
@@ -59,7 +59,7 @@ type vspdConfig struct {
 	HomeDir     string `long:"homedir" no-ini:"true" description:"Path to application home directory. Used for storing VSP database and logs."`
 	ConfigFile  string `long:"configfile" no-ini:"true" description:"DEPRECATED: This behavior is no longer available and this option will be removed in a future version of the software."`
 
-	// The following fields are derived from the above fields by loadConfig().
+	// The following fields are derived from the above fields by LoadConfig().
 	dataDir                                   string
 	network                                   *config.Network
 	dcrdCert                                  []byte
@@ -67,27 +67,27 @@ type vspdConfig struct {
 	walletCerts                               [][]byte
 }
 
-func (cfg *vspdConfig) Network() *config.Network {
+func (cfg *Config) Network() *config.Network {
 	return cfg.network
 }
 
-func (cfg *vspdConfig) LogDir() string {
+func (cfg *Config) LogDir() string {
 	return filepath.Join(cfg.HomeDir, "logs", cfg.network.Name)
 }
 
-func (cfg *vspdConfig) DatabaseFile() string {
+func (cfg *Config) DatabaseFile() string {
 	return filepath.Join(cfg.dataDir, dbFilename)
 }
 
-func (cfg *vspdConfig) DcrdDetails() (string, string, string, []byte) {
+func (cfg *Config) DcrdDetails() (string, string, string, []byte) {
 	return cfg.DcrdUser, cfg.DcrdPass, cfg.DcrdHost, cfg.dcrdCert
 }
 
-func (cfg *vspdConfig) WalletDetails() ([]string, []string, []string, [][]byte) {
+func (cfg *Config) WalletDetails() ([]string, []string, []string, [][]byte) {
 	return cfg.walletUsers, cfg.walletPasswords, cfg.walletHosts, cfg.walletCerts
 }
 
-var defaultConfig = vspdConfig{
+var DefaultConfig = Config{
 	Listen:         ":8800",
 	LogLevel:       "debug",
 	MaxLogSize:     int64(10),
@@ -175,7 +175,7 @@ func normalizeAddress(addr, defaultPort string) string {
 	return addr
 }
 
-// loadConfig initializes and parses the config using a config file and command
+// LoadConfig initializes and parses the config using a config file and command
 // line options.
 //
 // The configuration proceeds as follows:
@@ -187,8 +187,8 @@ func normalizeAddress(addr, defaultPort string) string {
 // The above results in vspd functioning properly without any config settings
 // while still allowing the user to override settings with config files and
 // command line options.  Command line options always take precedence.
-func loadConfig() (*vspdConfig, error) {
-	cfg := defaultConfig
+func LoadConfig() (*Config, error) {
+	cfg := DefaultConfig
 
 	// If command line options are requesting help, write it to stdout and exit.
 	if config.WriteHelp(&cfg) {


### PR DESCRIPTION
This enables the config to be reused in multiple binaries - eg. the upcoming vsp admin binary which will be responsible for writing a default config file for new vspd deployments.