### PR TITLE
types: Remove Revoked from VSP info response.

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2023 The Decred developers
+// Copyright (c) 2022-2024 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -18,7 +18,7 @@ import (
 
 	"github.com/decred/dcrd/txscript/v4/stdaddr"
 	"github.com/decred/slog"
-	"github.com/decred/vspd/types/v2"
+	"github.com/decred/vspd/types/v3"
 )
 
 type Client struct {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -14,7 +14,7 @@ import (
 	"testing"
 
 	"github.com/decred/slog"
-	"github.com/decred/vspd/types/v2"
+	"github.com/decred/vspd/types/v3"
 )
 
 // TestErrorDetails ensures errors returned by client.do contain adequate

--- a/client/go.mod
+++ b/client/go.mod
@@ -1,12 +1,14 @@
-module github.com/decred/vspd/client/v3
+module github.com/decred/vspd/client/v4
 
 go 1.19
 
 require (
 	github.com/decred/dcrd/txscript/v4 v4.1.0
 	github.com/decred/slog v1.2.0
-	github.com/decred/vspd/types/v2 v2.1.0
+	github.com/decred/vspd/types/v3 v3.0.0
 )
+
+replace github.com/decred/vspd/types/v3 => ../types
 
 require (
 	github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412 // indirect

--- a/client/go.sum
+++ b/client/go.sum
@@ -24,8 +24,6 @@ github.com/decred/dcrd/wire v1.6.0 h1:YOGwPHk4nzGr6OIwUGb8crJYWDiVLpuMxfDBCCF7s/
 github.com/decred/dcrd/wire v1.6.0/go.mod h1:XQ8Xv/pN/3xaDcb7sH8FBLS9cdgVctT7HpBKKGsIACk=
 github.com/decred/slog v1.2.0 h1:soHAxV52B54Di3WtKLfPum9OFfWqwtf/ygf9njdfnPM=
 github.com/decred/slog v1.2.0/go.mod h1:kVXlGnt6DHy2fV5OjSeuvCJ0OmlmTF6LFpEPMu/fOY0=
-github.com/decred/vspd/types/v2 v2.1.0 h1:cUVlmHPeLVsksPRnr2WHsmC2t1Skl6g1WH0HmpcPS7w=
-github.com/decred/vspd/types/v2 v2.1.0/go.mod h1:2xnNqedkt9GuL+pK8uIzDxqYxFlwLRflYFJH64b76n0=
 github.com/klauspost/cpuid/v2 v2.2.5 h1:0E5MSMDEoAulmXNFquVs//DdoomxaoTY1kUhbc/qbZg=
 github.com/klauspost/cpuid/v2 v2.2.5/go.mod h1:Lcz8mBdAVJIBVzewtcLocK12l3Y+JytZYpaMropDUws=
 golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/cmd/v3tool/main.go
+++ b/cmd/v3tool/main.go
@@ -14,10 +14,10 @@ import (
 	"time"
 
 	"github.com/decred/slog"
-	"github.com/decred/vspd/client/v3"
+	"github.com/decred/vspd/client/v4"
 	"github.com/decred/vspd/internal/config"
 	"github.com/decred/vspd/internal/signal"
-	"github.com/decred/vspd/types/v2"
+	"github.com/decred/vspd/types/v3"
 )
 
 const (

--- a/docs/api.md
+++ b/docs/api.md
@@ -56,7 +56,6 @@ when a VSP is closed will result in an error.
         "voted":25,
         "totalvotingwallets":3,
         "votingwalletsonline":3,
-        "revoked":3,
         "expired":2,
         "missed":1,
         "blockheight":623212,

--- a/go.mod
+++ b/go.mod
@@ -16,8 +16,8 @@ require (
 	github.com/decred/dcrd/txscript/v4 v4.1.0
 	github.com/decred/dcrd/wire v1.6.0
 	github.com/decred/slog v1.2.0
-	github.com/decred/vspd/client/v3 v3.0.0
-	github.com/decred/vspd/types/v2 v2.1.0
+	github.com/decred/vspd/client/v4 v4.0.0
+	github.com/decred/vspd/types/v3 v3.0.0
 	github.com/dustin/go-humanize v1.0.1
 	github.com/gin-gonic/gin v1.10.0
 	github.com/gorilla/sessions v1.2.2
@@ -26,6 +26,11 @@ require (
 	github.com/jrick/logrotate v1.0.0
 	github.com/jrick/wsrpc/v2 v2.3.5
 	go.etcd.io/bbolt v1.3.9
+)
+
+replace (
+	github.com/decred/vspd/client/v4 => ./client
+	github.com/decred/vspd/types/v3 => ./types
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -54,10 +54,6 @@ github.com/decred/dcrd/wire v1.6.0 h1:YOGwPHk4nzGr6OIwUGb8crJYWDiVLpuMxfDBCCF7s/
 github.com/decred/dcrd/wire v1.6.0/go.mod h1:XQ8Xv/pN/3xaDcb7sH8FBLS9cdgVctT7HpBKKGsIACk=
 github.com/decred/slog v1.2.0 h1:soHAxV52B54Di3WtKLfPum9OFfWqwtf/ygf9njdfnPM=
 github.com/decred/slog v1.2.0/go.mod h1:kVXlGnt6DHy2fV5OjSeuvCJ0OmlmTF6LFpEPMu/fOY0=
-github.com/decred/vspd/client/v3 v3.0.0 h1:4gAGDTeIU0r4quCxmV5Ez7T2J+P+OLPSibkCF+/Yb6w=
-github.com/decred/vspd/client/v3 v3.0.0/go.mod h1:5pfPvIa6V38AmophMrKUCl3KMpEIxcltWtgL2R+wsW8=
-github.com/decred/vspd/types/v2 v2.1.0 h1:cUVlmHPeLVsksPRnr2WHsmC2t1Skl6g1WH0HmpcPS7w=
-github.com/decred/vspd/types/v2 v2.1.0/go.mod h1:2xnNqedkt9GuL+pK8uIzDxqYxFlwLRflYFJH64b76n0=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/gabriel-vasile/mimetype v1.4.3 h1:in2uUcidCuFcDKtdcBxlR0rJ1+fsokWf+uqxgUFjbI0=

--- a/internal/webapi/getfeeaddress.go
+++ b/internal/webapi/getfeeaddress.go
@@ -12,7 +12,7 @@ import (
 	"github.com/decred/dcrd/dcrutil/v4"
 	"github.com/decred/vspd/database"
 	"github.com/decred/vspd/rpc"
-	"github.com/decred/vspd/types/v2"
+	"github.com/decred/vspd/types/v3"
 	"github.com/gin-gonic/gin"
 	"github.com/gin-gonic/gin/binding"
 )

--- a/internal/webapi/middleware.go
+++ b/internal/webapi/middleware.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2023 The Decred developers
+// Copyright (c) 2020-2024 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -15,7 +15,7 @@ import (
 
 	"github.com/decred/dcrd/blockchain/stake/v5"
 	"github.com/decred/vspd/rpc"
-	"github.com/decred/vspd/types/v2"
+	"github.com/decred/vspd/types/v3"
 	"github.com/gin-gonic/gin"
 	"github.com/gin-gonic/gin/binding"
 	"github.com/gorilla/sessions"

--- a/internal/webapi/payfee.go
+++ b/internal/webapi/payfee.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2023 The Decred developers
+// Copyright (c) 2021-2024 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -15,7 +15,7 @@ import (
 	"github.com/decred/dcrd/txscript/v4/stdaddr"
 	"github.com/decred/vspd/database"
 	"github.com/decred/vspd/rpc"
-	"github.com/decred/vspd/types/v2"
+	"github.com/decred/vspd/types/v3"
 	"github.com/gin-gonic/gin"
 	"github.com/gin-gonic/gin/binding"
 )

--- a/internal/webapi/setaltsignaddr.go
+++ b/internal/webapi/setaltsignaddr.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2023 The Decred developers
+// Copyright (c) 2021-2024 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -11,7 +11,7 @@ import (
 	"github.com/decred/dcrd/txscript/v4/stdaddr"
 	"github.com/decred/vspd/database"
 	"github.com/decred/vspd/rpc"
-	"github.com/decred/vspd/types/v2"
+	"github.com/decred/vspd/types/v3"
 	"github.com/gin-gonic/gin"
 	"github.com/gin-gonic/gin/binding"
 )

--- a/internal/webapi/setaltsignaddr_test.go
+++ b/internal/webapi/setaltsignaddr_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2023 The Decred developers
+// Copyright (c) 2021-2024 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -22,7 +22,7 @@ import (
 	"github.com/decred/slog"
 	"github.com/decred/vspd/database"
 	"github.com/decred/vspd/internal/config"
-	"github.com/decred/vspd/types/v2"
+	"github.com/decred/vspd/types/v3"
 	"github.com/gin-gonic/gin"
 )
 

--- a/internal/webapi/setvotechoices.go
+++ b/internal/webapi/setvotechoices.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2023 The Decred developers
+// Copyright (c) 2020-2024 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -11,7 +11,7 @@ import (
 
 	"github.com/decred/vspd/database"
 	"github.com/decred/vspd/rpc"
-	"github.com/decred/vspd/types/v2"
+	"github.com/decred/vspd/types/v3"
 	"github.com/gin-gonic/gin"
 	"github.com/gin-gonic/gin/binding"
 )

--- a/internal/webapi/ticketstatus.go
+++ b/internal/webapi/ticketstatus.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2022 The Decred developers
+// Copyright (c) 2020-2024 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/decred/vspd/database"
-	"github.com/decred/vspd/types/v2"
+	"github.com/decred/vspd/types/v3"
 	"github.com/gin-gonic/gin"
 	"github.com/gin-gonic/gin/binding"
 )

--- a/internal/webapi/vspinfo.go
+++ b/internal/webapi/vspinfo.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2023 The Decred developers
+// Copyright (c) 2020-2024 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/decred/vspd/internal/version"
-	"github.com/decred/vspd/types/v2"
+	"github.com/decred/vspd/types/v3"
 	"github.com/gin-gonic/gin"
 )
 

--- a/internal/webapi/vspinfo.go
+++ b/internal/webapi/vspinfo.go
@@ -29,7 +29,6 @@ func (w *WebAPI) vspInfo(c *gin.Context) {
 		Voted:               cachedStats.Voted,
 		TotalVotingWallets:  cachedStats.TotalVotingWallets,
 		VotingWalletsOnline: cachedStats.VotingWalletsOnline,
-		Revoked:             cachedStats.Expired + cachedStats.Missed,
 		Expired:             cachedStats.Expired,
 		Missed:              cachedStats.Missed,
 		BlockHeight:         cachedStats.BlockHeight,

--- a/internal/webapi/webapi.go
+++ b/internal/webapi/webapi.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2023 The Decred developers
+// Copyright (c) 2020-2024 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -21,7 +21,7 @@ import (
 	"github.com/decred/vspd/database"
 	"github.com/decred/vspd/internal/config"
 	"github.com/decred/vspd/rpc"
-	"github.com/decred/vspd/types/v2"
+	"github.com/decred/vspd/types/v3"
 	"github.com/dustin/go-humanize"
 	"github.com/gin-gonic/gin"
 	"github.com/gorilla/sessions"

--- a/types/go.mod
+++ b/types/go.mod
@@ -1,3 +1,3 @@
-module github.com/decred/vspd/types/v2
+module github.com/decred/vspd/types/v3
 
 go 1.19

--- a/types/types.go
+++ b/types/types.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2023 The Decred developers
+// Copyright (c) 2020-2024 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 

--- a/types/types.go
+++ b/types/types.go
@@ -24,13 +24,10 @@ type VspInfoResponse struct {
 	Voted               int64   `json:"voted"`
 	TotalVotingWallets  int64   `json:"totalvotingwallets"`
 	VotingWalletsOnline int64   `json:"votingwalletsonline"`
-	// Deprecated: Revoked will be removed in the next major version bump.
-	// Revoked is simply the sum of Expired and Missed, so use those instead.
-	Revoked           int64   `json:"revoked"`
-	Expired           int64   `json:"expired"`
-	Missed            int64   `json:"missed"`
-	BlockHeight       uint32  `json:"blockheight"`
-	NetworkProportion float32 `json:"estimatednetworkproportion"`
+	Expired             int64   `json:"expired"`
+	Missed              int64   `json:"missed"`
+	BlockHeight         uint32  `json:"blockheight"`
+	NetworkProportion   float32 `json:"estimatednetworkproportion"`
 }
 
 type FeeAddressRequest struct {


### PR DESCRIPTION
This was marked as deprecated in the previous release and is now being removed.