### PR TITLE
vspadmin: Add retirexpub command

### DIFF
--- a/cmd/vspadmin/README.md
+++ b/cmd/vspadmin/README.md
@@ -38,3 +38,17 @@ Example:
 ```no-highlight
 $ go run ./cmd/vspadmin writeconfig
 ```
+
+### `retirexpub`
+
+Replaces the currently used xpub with a new one. Once an xpub key has been
+retired it can not be used by the VSP again.
+
+**Note:** vspd must be stopped before this command can be used because it
+modifies values in the vspd database.
+
+Example:
+
+```no-highlight
+$ go run ./cmd/vspadmin retirexpub <xpub>
+```

--- a/database/database.go
+++ b/database/database.go
@@ -39,14 +39,13 @@ var (
 	voteChangeBktK = []byte("votechangebkt")
 	// version is the current database version.
 	versionK = []byte("version")
-	// feeXPub is the extended public key used for collecting VSP fees.
-	feeXPubK = []byte("feeXPub")
+	// xPubBktK stores current and historic extended public keys used for
+	// collecting VSP fees.
+	xPubBktK = []byte("xpubbkt")
 	// cookieSecret is the secret key for initializing the cookie store.
 	cookieSecretK = []byte("cookieSecret")
 	// privatekey is the private key.
 	privateKeyK = []byte("privatekey")
-	// lastaddressindex is the index of the last address used for fees.
-	lastAddressIndexK = []byte("lastaddressindex")
 	// altSignAddrBktK stores alternate signing addresses.
 	altSignAddrBktK = []byte("altsigbkt")
 )
@@ -137,12 +136,14 @@ func CreateNew(dbFile, feeXPub string) error {
 			return err
 		}
 
-		// Store fee xpub.
-		xpub := FeeXPub{
+		// Insert the initial fee xpub with ID 0.
+		newKey := FeeXPub{
+			ID:          0,
 			Key:         feeXPub,
 			LastUsedIdx: 0,
+			Retired:     0,
 		}
-		err = insertFeeXPub(tx, xpub)
+		err = insertFeeXPub(tx, newKey)
 		if err != nil {
 			return err
 		}

--- a/database/database_test.go
+++ b/database/database_test.go
@@ -78,6 +78,7 @@ func TestDatabase(t *testing.T) {
 		"testFilterTickets":     testFilterTickets,
 		"testCountTickets":      testCountTickets,
 		"testFeeXPub":           testFeeXPub,
+		"testRetireFeeXPub":     testRetireFeeXPub,
 		"testDeleteTicket":      testDeleteTicket,
 		"testVoteChangeRecords": testVoteChangeRecords,
 		"testHTTPBackup":        testHTTPBackup,

--- a/database/feexpub_test.go
+++ b/database/feexpub_test.go
@@ -9,8 +9,7 @@ import (
 )
 
 func testFeeXPub(t *testing.T) {
-	// A newly created DB should store the fee xpub it was initialized with, and
-	// the last used index should be 0.
+	// A newly created DB should store the fee xpub it was initialized with.
 	retrievedXPub, err := db.FeeXPub()
 	if err != nil {
 		t.Fatalf("error getting fee xpub: %v", err)
@@ -20,8 +19,15 @@ func testFeeXPub(t *testing.T) {
 		t.Fatalf("expected fee xpub %v, got %v", feeXPub, retrievedXPub.Key)
 	}
 
+	// The ID, last used index and retirement timestamp should all be 0
+	if retrievedXPub.ID != 0 {
+		t.Fatalf("expected xpub ID 0, got %d", retrievedXPub.ID)
+	}
 	if retrievedXPub.LastUsedIdx != 0 {
-		t.Fatalf("retrieved addr index value didnt match expected")
+		t.Fatalf("expected xpub last used 0, got %d", retrievedXPub.LastUsedIdx)
+	}
+	if retrievedXPub.Retired != 0 {
+		t.Fatalf("expected xpub retirement 0, got %d", retrievedXPub.Retired)
 	}
 
 	// Update address index.
@@ -34,9 +40,20 @@ func testFeeXPub(t *testing.T) {
 	// Check for updated value.
 	retrievedXPub, err = db.FeeXPub()
 	if err != nil {
-		t.Fatalf("error getting address index: %v", err)
+		t.Fatalf("error getting fee xpub: %v", err)
 	}
-	if idx != retrievedXPub.LastUsedIdx {
-		t.Fatalf("retrieved addr index value didnt match expected")
+	if retrievedXPub.LastUsedIdx != idx {
+		t.Fatalf("expected xpub last used %d, got %d", idx, retrievedXPub.LastUsedIdx)
+	}
+
+	// Key, ID and retirement timestamp should be unchanged.
+	if retrievedXPub.Key != feeXPub {
+		t.Fatalf("expected fee xpub %v, got %v", feeXPub, retrievedXPub.Key)
+	}
+	if retrievedXPub.ID != 0 {
+		t.Fatalf("expected xpub ID 0, got %d", retrievedXPub.ID)
+	}
+	if retrievedXPub.Retired != 0 {
+		t.Fatalf("expected xpub retirement 0, got %d", retrievedXPub.Retired)
 	}
 }

--- a/database/ticket.go
+++ b/database/ticket.go
@@ -50,6 +50,7 @@ var (
 	hashK              = []byte("Hash")
 	purchaseHeightK    = []byte("PurchaseHeight")
 	commitmentAddressK = []byte("CommitmentAddress")
+	feeAddressXPubIDK  = []byte("FeeAddressXPubID")
 	feeAddressIndexK   = []byte("FeeAddressIndex")
 	feeAddressK        = []byte("FeeAddress")
 	feeAmountK         = []byte("FeeAmount")
@@ -69,6 +70,7 @@ type Ticket struct {
 	Hash              string
 	PurchaseHeight    int64
 	CommitmentAddress string
+	FeeAddressXPubID  uint32
 	FeeAddressIndex   uint32
 	FeeAddress        string
 	FeeAmount         int64
@@ -184,6 +186,9 @@ func putTicketInBucket(bkt *bolt.Bucket, ticket Ticket) error {
 	if err = bkt.Put(feeAddressIndexK, uint32ToBytes(ticket.FeeAddressIndex)); err != nil {
 		return err
 	}
+	if err = bkt.Put(feeAddressXPubIDK, uint32ToBytes(ticket.FeeAddressXPubID)); err != nil {
+		return err
+	}
 	if err = bkt.Put(feeAmountK, int64ToBytes(ticket.FeeAmount)); err != nil {
 		return err
 	}
@@ -216,6 +221,7 @@ func getTicketFromBkt(bkt *bolt.Bucket) (Ticket, error) {
 	ticket.Outcome = TicketOutcome(bkt.Get(outcomeK))
 
 	ticket.PurchaseHeight = bytesToInt64(bkt.Get(purchaseHeightK))
+	ticket.FeeAddressXPubID = bytesToUint32(bkt.Get(feeAddressXPubIDK))
 	ticket.FeeAddressIndex = bytesToUint32(bkt.Get(feeAddressIndexK))
 	ticket.FeeAmount = bytesToInt64(bkt.Get(feeAmountK))
 	ticket.FeeExpiration = bytesToInt64(bkt.Get(feeExpirationK))

--- a/database/ticket_test.go
+++ b/database/ticket_test.go
@@ -17,6 +17,7 @@ func exampleTicket() Ticket {
 		Hash:              randString(64, hexCharset),
 		CommitmentAddress: randString(35, addrCharset),
 		FeeAddressIndex:   12345,
+		FeeAddressXPubID:  10,
 		FeeAddress:        randString(35, addrCharset),
 		FeeAmount:         10000000,
 		FeeExpiration:     4,
@@ -129,6 +130,7 @@ func testUpdateTicket(t *testing.T) {
 	ticket.FeeAmount = ticket.FeeAmount + 1
 	ticket.FeeExpiration = ticket.FeeExpiration + 1
 	ticket.VoteChoices = map[string]string{"New agenda": "New value"}
+	ticket.FeeAddressXPubID = 20
 
 	err = db.UpdateTicket(ticket)
 	if err != nil {

--- a/database/upgrade_v5.go
+++ b/database/upgrade_v5.go
@@ -1,0 +1,92 @@
+// Copyright (c) 2024 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package database
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/decred/slog"
+	bolt "go.etcd.io/bbolt"
+)
+
+func xPubBucketUpgrade(db *bolt.DB, log slog.Logger) error {
+	log.Infof("Upgrading database to version %d", xPubBucketVersion)
+
+	// feeXPub is the key which was used prior to this upgrade to store the xpub
+	// in the root bucket.
+	feeXPubK := []byte("feeXPub")
+
+	// lastaddressindex is the key which was used prior to this upgrade to store
+	// the index of the last used address in the root bucket.
+	lastAddressIndexK := []byte("lastaddressindex")
+
+	// Run the upgrade in a single database transaction so it can be safely
+	// rolled back if an error is encountered.
+	err := db.Update(func(tx *bolt.Tx) error {
+		vspBkt := tx.Bucket(vspBktK)
+		ticketBkt := vspBkt.Bucket(ticketBktK)
+
+		// Retrieve the current xpub.
+		xpubBytes := vspBkt.Get(feeXPubK)
+		if xpubBytes == nil {
+			return errors.New("xpub not found")
+		}
+		feeXPub := string(xpubBytes)
+
+		// Retrieve the current last addr index. Could be nil if this xpub was
+		// never used.
+		idxBytes := vspBkt.Get(lastAddressIndexK)
+		var idx uint32
+		if idxBytes != nil {
+			idx = bytesToUint32(idxBytes)
+		}
+
+		// Delete the old values from the database.
+		err := vspBkt.Delete(feeXPubK)
+		if err != nil {
+			return fmt.Errorf("could not delete xpub: %w", err)
+		}
+		err = vspBkt.Delete(lastAddressIndexK)
+		if err != nil {
+			return fmt.Errorf("could not delete last addr idx: %w", err)
+		}
+
+		// Insert the key into the bucket.
+		newXpub := FeeXPub{
+			ID:          0,
+			Key:         feeXPub,
+			LastUsedIdx: idx,
+			Retired:     0,
+		}
+		err = insertFeeXPub(tx, newXpub)
+		if err != nil {
+			return fmt.Errorf("failed to store xpub in new bucket: %w", err)
+		}
+
+		// Update all existing tickets with xpub key ID 0.
+		err = ticketBkt.ForEachBucket(func(k []byte) error {
+			return ticketBkt.Bucket(k).Put(feeAddressXPubIDK, uint32ToBytes(0))
+		})
+		if err != nil {
+			return fmt.Errorf("setting ticket xpub ID to 0 failed: %w", err)
+		}
+
+		// Update database version.
+		err = vspBkt.Put(versionK, uint32ToBytes(xPubBucketVersion))
+		if err != nil {
+			return fmt.Errorf("failed to update db version: %w", err)
+		}
+
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	log.Info("Upgrade completed")
+
+	return nil
+}

--- a/database/upgrades.go
+++ b/database/upgrades.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2022 The Decred developers
+// Copyright (c) 2021-2024 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -30,10 +30,17 @@ const (
 	// to verify messages sent to the vspd.
 	altSignAddrVersion = 4
 
+	// xPubBucketVersion changes how the xpub key and its associated addr index
+	// are stored. Previously only a single key was supported because it was
+	// stored as a single value in the root bucket. Now a dedicated bucket which
+	// can hold multiple keys is used, enabling support for historic retired
+	// keys as well as the current key.
+	xPubBucketVersion = 5
+
 	// latestVersion is the latest version of the database that is understood by
 	// vspd. Databases with recorded versions higher than this will fail to open
 	// (meaning any upgrades prevent reverting to older software).
-	latestVersion = altSignAddrVersion
+	latestVersion = xPubBucketVersion
 )
 
 // upgrades maps between old database versions and the upgrade function to
@@ -42,6 +49,7 @@ var upgrades = []func(tx *bolt.DB, log slog.Logger) error{
 	initialVersion:        removeOldFeeTxUpgrade,
 	removeOldFeeTxVersion: ticketBucketUpgrade,
 	ticketBucketVersion:   altSignAddrUpgrade,
+	altSignAddrVersion:    xPubBucketUpgrade,
 }
 
 // v1Ticket has the json tags required to unmarshal tickets stored in the

--- a/internal/webapi/addressgenerator.go
+++ b/internal/webapi/addressgenerator.go
@@ -18,6 +18,7 @@ type addressGenerator struct {
 	external      *hdkeychain.ExtendedKey
 	netParams     *chaincfg.Params
 	lastUsedIndex uint32
+	feeXPubID     uint32
 	log           slog.Logger
 }
 
@@ -41,8 +42,13 @@ func newAddressGenerator(xPub database.FeeXPub, netParams *chaincfg.Params, log 
 		external:      external,
 		netParams:     netParams,
 		lastUsedIndex: xPub.LastUsedIdx,
+		feeXPubID:     xPub.ID,
 		log:           log,
 	}, nil
+}
+
+func (m *addressGenerator) xPubID() uint32 {
+	return m.feeXPubID
 }
 
 // nextAddress increments the last used address counter and returns a new

--- a/internal/webapi/admin.go
+++ b/internal/webapi/admin.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2023 The Decred developers
+// Copyright (c) 2020-2024 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -155,12 +155,20 @@ func (w *WebAPI) adminPage(c *gin.Context) {
 
 	missed.SortByPurchaseHeight()
 
+	xpubs, err := w.db.AllXPubs()
+	if err != nil {
+		w.log.Errorf("db.AllXPubs error: %v", err)
+		c.String(http.StatusInternalServerError, "Error getting xpubs from db")
+		return
+	}
+
 	c.HTML(http.StatusOK, "admin.html", gin.H{
 		"WebApiCache":   cacheData,
 		"WebApiCfg":     w.cfg,
 		"WalletStatus":  w.walletStatus(c),
 		"DcrdStatus":    w.dcrdStatus(c),
 		"MissedTickets": missed,
+		"XPubs":         xpubs,
 	})
 }
 
@@ -231,6 +239,13 @@ func (w *WebAPI) ticketSearch(c *gin.Context) {
 
 	missed.SortByPurchaseHeight()
 
+	xpubs, err := w.db.AllXPubs()
+	if err != nil {
+		w.log.Errorf("db.AllXPubs error: %v", err)
+		c.String(http.StatusInternalServerError, "Error getting xpubs from db")
+		return
+	}
+
 	c.HTML(http.StatusOK, "admin.html", gin.H{
 		"SearchResult": searchResult{
 			Hash:            hash,
@@ -246,6 +261,7 @@ func (w *WebAPI) ticketSearch(c *gin.Context) {
 		"WalletStatus":  w.walletStatus(c),
 		"DcrdStatus":    w.dcrdStatus(c),
 		"MissedTickets": missed,
+		"XPubs":         xpubs,
 	})
 }
 

--- a/internal/webapi/getfeeaddress.go
+++ b/internal/webapi/getfeeaddress.go
@@ -195,6 +195,7 @@ func (w *WebAPI) feeAddress(c *gin.Context) {
 		PurchaseHeight:    purchaseHeight,
 		CommitmentAddress: commitmentAddress,
 		FeeAddressIndex:   newAddressIdx,
+		FeeAddressXPubID:  w.addrGen.xPubID(),
 		FeeAddress:        newAddress,
 		Confirmed:         confirmed,
 		FeeAmount:         int64(fee),

--- a/internal/webapi/public/css/vspd.css
+++ b/internal/webapi/public/css/vspd.css
@@ -246,7 +246,9 @@ table.missed-tickets td {
 .tabset > input:nth-child(4):focus ~ ul li:nth-child(4) label,
 .tabset > input:nth-child(4):hover ~ ul li:nth-child(4) label,
 .tabset > input:nth-child(5):focus ~ ul li:nth-child(5) label,
-.tabset > input:nth-child(5):hover ~ ul li:nth-child(5) label {
+.tabset > input:nth-child(5):hover ~ ul li:nth-child(5) label,
+.tabset > input:nth-child(6):focus ~ ul li:nth-child(6) label,
+.tabset > input:nth-child(6):hover ~ ul li:nth-child(6) label {
     cursor: pointer;
     color: #091440;
 }
@@ -255,7 +257,8 @@ table.missed-tickets td {
 .tabset > input:nth-child(2):checked ~ ul li:nth-child(2) label,
 .tabset > input:nth-child(3):checked ~ ul li:nth-child(3) label,
 .tabset > input:nth-child(4):checked ~ ul li:nth-child(4) label,
-.tabset > input:nth-child(5):checked ~ ul li:nth-child(5) label {
+.tabset > input:nth-child(5):checked ~ ul li:nth-child(5) label,
+.tabset > input:nth-child(6):checked ~ ul li:nth-child(6) label {
     border-bottom: 5px solid #2ed8a3;
     color: #091440;
     cursor: default;
@@ -275,6 +278,7 @@ table.missed-tickets td {
 .tabset > input:nth-child(2):checked ~ div > section:nth-child(2),
 .tabset > input:nth-child(3):checked ~ div > section:nth-child(3),
 .tabset > input:nth-child(4):checked ~ div > section:nth-child(4),
-.tabset > input:nth-child(5):checked ~ div > section:nth-child(5) {
+.tabset > input:nth-child(5):checked ~ div > section:nth-child(5),
+.tabset > input:nth-child(6):checked ~ div > section:nth-child(6) {
     position:static;
 }

--- a/internal/webapi/templates/admin.html
+++ b/internal/webapi/templates/admin.html
@@ -51,12 +51,19 @@
                         id="tabset_1_5"
                         hidden
                     >
+                    <input
+                        type="radio"
+                        name="tabset_1"
+                        id="tabset_1_6"
+                        hidden
+                    >
                     <ul>
                         <li><label for="tabset_1_1">VSP Status</label></li>
                         <li><label for="tabset_1_2">Ticket Search</label></li>
                         <li><label for="tabset_1_3">Missed Tickets</label></li>
-                        <li><label for="tabset_1_4">Database</label></li>
-                        <li><label for="tabset_1_5">Logout</label></li>
+                        <li><label for="tabset_1_4">Fee X Pubs</label></li>
+                        <li><label for="tabset_1_5">Database</label></li>
+                        <li><label for="tabset_1_6">Logout</label></li>
                     </ul>
                     
                     <div>
@@ -215,6 +222,30 @@
                                                 <button class="btn btn-link p-0 code" type="submit">{{ .Hash }}</button>
                                             </form>
                                         </td>
+                                    </tr>
+                                {{ end }}
+                                </tbody>
+                            </table>
+                            {{ end}}
+                        </section>
+
+                        <section>
+                            <h1>All X Pubs</h1>
+                            {{ with .XPubs }}
+                            <table class="mx-auto">
+                                <thead>
+                                    <th>ID</th>
+                                    <th>Key</th>
+                                    <th>Last Address Index</th>
+                                    <th>Retired</th>
+                                </thead>
+                                <tbody>
+                                {{ range . }}
+                                    <tr>
+                                        <td>{{ .ID }}</td>
+                                        <td>{{ .Key }}</td>
+                                        <td>{{ .LastUsedIdx }}</td>
+                                        <td>{{ dateTime .Retired }}</td>
                                     </tr>
                                 {{ end }}
                                 </tbody>

--- a/internal/webapi/templates/ticket-search-result.html
+++ b/internal/webapi/templates/ticket-search-result.html
@@ -51,11 +51,8 @@
                     <a href="{{ addressURL .Ticket.FeeAddress }}">
                         {{ .Ticket.FeeAddress }}
                     </a>
+                    (XPub ID: {{ .Ticket.FeeAddressXPubID }} Address: {{ .Ticket.FeeAddressIndex }})
                 </td>
-            </tr>
-            <tr>
-                <th>Fee Address Index</th>
-                <td>{{ .Ticket.FeeAddressIndex }}</td>
             </tr>
             <tr>
                 <th>Fee Amount</th>


### PR DESCRIPTION
**Database Upgrade Warning**

This PR adds a new command `retirexpub` to vspadmin. It opens an existing vspd database and replaces the currently used xpub with a new one. A database upgrade was required in order to support this functionality.

Current and historic xpubs are displayed on a new tab in the admin page of the web UI.

Closes #461 