### PR TITLE
v3tool: Continue if a ticket already has paid fee.

### DIFF
--- a/cmd/v3tool/main.go
+++ b/cmd/v3tool/main.go
@@ -144,6 +144,13 @@ func run() int {
 			if errors.Is(err, context.Canceled) {
 				return 0
 			}
+
+			// Continue to the next ticket if this one already has a paid fee.
+			var apiErr types.ErrorResponse
+			if errors.As(err, &apiErr) && apiErr.Code == types.ErrFeeAlreadyReceived {
+				continue
+			}
+
 			log.Errorf("getFeeAddress error: %v", err)
 			return 1
 		}


### PR DESCRIPTION
v3tool will now attempt to register all tickets with the VSP rather than immediately exiting if one of the tickets already has a paid fee.