### PR TITLE
webapi: Distinguish between current/old xpub

### DIFF
--- a/internal/webapi/admin.go
+++ b/internal/webapi/admin.go
@@ -160,12 +160,22 @@ func (w *WebAPI) renderAdmin(c *gin.Context, searchResult *searchResult) {
 
 	missed.SortByPurchaseHeight()
 
-	xpubs, err := w.db.AllXPubs()
+	currentXPub, err := w.db.FeeXPub()
 	if err != nil {
-		w.log.Errorf("db.AllXPubs error: %v", err)
-		c.String(http.StatusInternalServerError, "Error getting xpubs from db")
+		w.log.Errorf("db.FeeXPub error: %v", err)
+		c.String(http.StatusInternalServerError, "Error getting current xpub from db")
 		return
 	}
+
+	oldXPubs, err := w.db.AllXPubs()
+	if err != nil {
+		w.log.Errorf("db.AllXPubs error: %v", err)
+		c.String(http.StatusInternalServerError, "Error getting all xpubs from db")
+		return
+	}
+
+	// Remove current xpub from the list of old xpubs.
+	delete(oldXPubs, currentXPub.ID)
 
 	c.HTML(http.StatusOK, "admin.html", gin.H{
 		"SearchResult":  searchResult,
@@ -174,7 +184,8 @@ func (w *WebAPI) renderAdmin(c *gin.Context, searchResult *searchResult) {
 		"WalletStatus":  w.walletStatus(c),
 		"DcrdStatus":    w.dcrdStatus(c),
 		"MissedTickets": missed,
-		"XPubs":         xpubs,
+		"CurrentXPub":   currentXPub,
+		"OldXPubs":      oldXPubs,
 	})
 }
 

--- a/internal/webapi/templates/admin.html
+++ b/internal/webapi/templates/admin.html
@@ -251,8 +251,26 @@
                     <div class="collapsible-tab-content">
 
                         <div class="p-2">
-                            <h1>All X Pubs</h1>
-                            {{ with .XPubs }}
+                            <h1>Current X Pub</h1>
+                            <table class="mx-auto">
+                                <thead>
+                                    <th>ID</th>
+                                    <th>Key</th>
+                                    <th>Last Address Index</th>
+                                </thead>
+                                <tbody>
+                                    <tr>
+                                        <td>{{ .CurrentXPub.ID }}</td>
+                                        <td>{{ .CurrentXPub.Key }}</td>
+                                        <td>{{ .CurrentXPub.LastUsedIdx }}</td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                        </div>
+
+                        {{ with .OldXPubs }}
+                        <div class="p-2">
+                            <h1>Old X Pubs</h1>
                             <table class="mx-auto">
                                 <thead>
                                     <th>ID</th>
@@ -271,8 +289,8 @@
                                 {{ end }}
                                 </tbody>
                             </table>
-                            {{ end}}
                         </div>
+                        {{ end }}
 
                     </div>
                 </section>


### PR DESCRIPTION
Based on #495 

Showing current and old pubkeys under separate headers makes the information easier to parse, and also fixes a bug where the current pubkey was showing a retired timestamp of unix epoch.

<details>
  <summary>Before screenshot</summary>
  <img src="https://github.com/user-attachments/assets/4619c372-6da8-410f-8cfc-3a835d07ecd9">
</details>

<details>
  <summary>After screenshot</summary>
  <img src="https://github.com/user-attachments/assets/2e850539-222a-4c65-b4c4-704dfce92cdf">
  <img src="https://github.com/user-attachments/assets/1f3e16ee-80d9-4ccc-ad11-161ab99d6594">
</details>



