### PR TITLE
ci: Bump linter to version 2.

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -17,6 +17,6 @@ jobs:
       - name: Build
         run: go build ./...
       - name: Install Linters
-        run: "curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.64.5"
+        run: "curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.0.2"
       - name: Test and Lint
         run: ./run_tests.sh

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,8 +1,8 @@
+version: "2"
 run:
-  deadline: 10m
-
+  timeout: 10m
 linters:
-  disable-all: true
+  default: none
   enable:
     - asciicheck
     - bidichk
@@ -17,9 +17,6 @@ linters:
     - fatcontext
     - goconst
     - godot
-    - gofmt
-    - goimports
-    - gosimple
     - govet
     - ineffassign
     - makezero
@@ -34,9 +31,16 @@ linters:
     - revive
     - staticcheck
     - tparallel
-    - typecheck
     - unconvert
-    - usestdlibvars
-    - usetesting
     - unparam
     - unused
+    - usestdlibvars
+    - usetesting
+  exclusions:
+    presets:
+      - comments
+      - std-error-handling
+formatters:
+  enable:
+    - gofmt
+    - goimports

--- a/cmd/vote-validator/results.go
+++ b/cmd/vote-validator/results.go
@@ -29,8 +29,8 @@ func (r *results) writeFile(path string) (bool, error) {
 		return false, fmt.Errorf("opening log file failed: %w", err)
 	}
 
-	write := func(f *os.File, str string, a ...any) {
-		_, err := f.WriteString(fmt.Sprintf(str+"\n", a...))
+	write := func(f *os.File, format string, a ...any) {
+		_, err := fmt.Fprintf(f, format+"\n", a...)
 		if err != nil {
 			f.Close()
 			panic(fmt.Sprintf("writing to log file failed: %v", err))


### PR DESCRIPTION
Various changes in this new major version, including a new config file format:

- "gofmt" and "goimports" are now categorized as formatters (instead of linters) and are moved to their own section.
- The functionality of "gosimple" has been bundled into "staticcheck".
- "typecheck" is now always on and cannot be independently enabled/disabled.