### PR TITLE
ci: Update linter to 2.12.2.

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -17,6 +17,6 @@ jobs:
       - name: Build
         run: go build ./...
       - name: Install Linters
-        run: "curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.9.0"
+        run: "curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/main/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.12.2"
       - name: Test and Lint
         run: ./run_tests.sh

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,7 +15,6 @@ linters:
     - errorlint
     - exhaustive
     - fatcontext
-    - goconst
     - godot
     - govet
     - ineffassign


### PR DESCRIPTION
Also:
- Remove goconst linter because its latest release is far too sensitive by default, and it doesn't offer enough value to be worth manual configuration.
- Pull the linter install script from the branch "main" rather than "master" as notified in the 2.12.0 release note https://github.com/golangci/golangci-lint/releases/tag/v2.12.0