### PR TITLE
Delete vote changes for unmined tickets.

### DIFF
--- a/database/database_test.go
+++ b/database/database_test.go
@@ -82,6 +82,7 @@ func TestDatabase(t *testing.T) {
 		"testRetireFeeXPub":      testRetireFeeXPub,
 		"testDeleteTicket":       testDeleteTicket,
 		"testVoteChangeRecords":  testVoteChangeRecords,
+		"testDeleteVoteChanges":  testDeleteVoteChanges,
 		"testHTTPBackup":         testHTTPBackup,
 		"testAltSignAddrData":    testAltSignAddrData,
 		"testInsertAltSignAddr":  testInsertAltSignAddr,

--- a/database/votechange.go
+++ b/database/votechange.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2024 The Decred developers
+// Copyright (c) 2020-2026 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -119,4 +119,25 @@ func (vdb *VspDatabase) GetVoteChanges(ticketHash string) (map[uint32]VoteChange
 	})
 
 	return records, err
+}
+
+// DeleteVoteChanges deletes all of the stored vote change records for the
+// provided ticket hash.
+func (vdb *VspDatabase) DeleteVoteChanges(ticketHash string) error {
+	return vdb.db.Update(func(tx *bolt.Tx) error {
+		voteChangeBkt := tx.Bucket(vspBktK).Bucket(voteChangeBktK)
+
+		// Don't attempt delete if doesn't exist.
+		bkt := voteChangeBkt.Bucket([]byte(ticketHash))
+		if bkt == nil {
+			return nil
+		}
+
+		err := voteChangeBkt.DeleteBucket([]byte(ticketHash))
+		if err != nil {
+			return fmt.Errorf("could not delete vote changes: %w", err)
+		}
+
+		return nil
+	})
 }

--- a/database/votechange_test.go
+++ b/database/votechange_test.go
@@ -61,3 +61,45 @@ func testVoteChangeRecords(t *testing.T) {
 		t.Fatalf("oldest vote change record should have been deleted")
 	}
 }
+
+func testDeleteVoteChanges(t *testing.T) {
+	const hash = "MyHash"
+	record := exampleRecord()
+
+	// Nothing to delete.
+	err := db.DeleteVoteChanges(hash)
+	if err != nil {
+		t.Fatalf("error deleting non-existent vote change record: %v", err)
+	}
+
+	// Insert a vote change record and confirm it can be retrieved.
+	err = db.SaveVoteChange(hash, record)
+	if err != nil {
+		t.Fatalf("error storing vote change record: %v", err)
+	}
+
+	retrieved, err := db.GetVoteChanges(hash)
+	if err != nil {
+		t.Fatalf("error retrieving vote change record: %v", err)
+	}
+
+	if len(retrieved) != 1 {
+		t.Fatalf("expected 1 vote change record, got %d", len(retrieved))
+	}
+
+	// Delete and confirm it is no longer in DB.
+	err = db.DeleteVoteChanges(hash)
+	if err != nil {
+		t.Fatalf("error deleting vote change record: %v", err)
+	}
+
+	retrieved, err = db.GetVoteChanges(hash)
+	if err != nil {
+		t.Fatalf("error retrieving vote change records: %v", err)
+	}
+
+	if len(retrieved) != 0 {
+		t.Fatalf("expected 0 vote change record, got %d", len(retrieved))
+	}
+
+}

--- a/internal/vspd/update.go
+++ b/internal/vspd/update.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2023 The Decred developers
+// Copyright (c) 2020-2026 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -82,6 +82,12 @@ func (v *Vspd) updateUnconfirmed(ctx context.Context, dcrdClient *rpc.DcrdRPC) {
 				err = v.db.DeleteTicket(ticket)
 				if err != nil {
 					v.log.Errorf("%s: db.DeleteTicket error (ticketHash=%s): %v",
+						funcName, ticket.Hash, err)
+				}
+
+				err = v.db.DeleteVoteChanges(ticket.Hash)
+				if err != nil {
+					v.log.Errorf("%s: db.DeleteVoteChanges error (ticketHash=%s): %v",
 						funcName, ticket.Hash, err)
 				}
 


### PR DESCRIPTION
If a mempool ticket is added to vspd but never mined, all of the data about that ticket should be deleted.

The alternate vote address and the ticket data itself was already being deleted, but the vote changes were mistakenly left in the DB.