### PR TITLE
Reduce request read limit from 4MiB to 1MiB.

### DIFF
--- a/internal/webapi/middleware.go
+++ b/internal/webapi/middleware.go
@@ -181,7 +181,7 @@ func (w *WebAPI) withWalletClients(wallets rpc.WalletConnect) gin.HandlerFunc {
 // drainAndReplaceBody will read and return the body of the provided request. It
 // replaces the request reader with an identical one so it can be used again.
 func drainAndReplaceBody(req *http.Request) ([]byte, error) {
-	const readLimit = 1 << 22 // 2 MiB
+	const readLimit = 1 << 20 // 1 MiB
 	bodyReader := io.LimitReader(req.Body, readLimit)
 	reqBytes, err := io.ReadAll(bodyReader)
 	if err != nil {


### PR DESCRIPTION
4MiB was set as a read limit somewhat arbitrarily, just to ensure there is some limit in place rather than allowing unlimited reads. This can be reduced to 1MiB and still comfortably fit a request containing even the maximum possible transaction hex.

Note that the comment here which stated 2MiB was incorrect and the actual value in use was 4MiB.