### PR TITLE
Set RequiredConfs per network.

### DIFF
--- a/internal/config/network.go
+++ b/internal/config/network.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2024 The Decred developers
+// Copyright (c) 2020-2026 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -19,6 +19,9 @@ type Network struct {
 	// deployment on this network. vspd will log an error and refuse to start if
 	// fewer wallets are configured.
 	MinWallets int
+	// RequiredConfs is the number of confirmations required to consider a
+	// ticket purchase or a fee transaction to be final.
+	RequiredConfs int64
 	// DCP0005Height is the activation height of DCP-0005 block header
 	// commitments agenda on this network.
 	DCP0005Height int64
@@ -36,6 +39,7 @@ var MainNet = Network{
 	WalletRPCServerPort: "9110",
 	BlockExplorerURL:    "https://dcrdata.decred.org",
 	MinWallets:          3,
+	RequiredConfs:       6,
 	// DCP0005Height on mainnet is block
 	// 000000000000000010815bed2c4dc431c34a859f4fc70774223dde788e95a01e.
 	DCP0005Height: 431488,
@@ -53,6 +57,7 @@ var TestNet3 = Network{
 	WalletRPCServerPort: "19110",
 	BlockExplorerURL:    "https://testnet.dcrdata.org",
 	MinWallets:          1,
+	RequiredConfs:       2,
 	// DCP0005Height on testnet3 is block
 	// 0000003e54421d585f4a609393a8694509af98f62b8449f245b09fe1389f8f77.
 	DCP0005Height: 323328,
@@ -70,6 +75,7 @@ var SimNet = Network{
 	WalletRPCServerPort: "19557",
 	BlockExplorerURL:    "...",
 	MinWallets:          1,
+	RequiredConfs:       2,
 	// DCP0005Height on simnet is 1 because the agenda will always be active.
 	DCP0005Height: 1,
 	// DCP0010Height on simnet is 1 because the agenda will always be active.

--- a/internal/vspd/update.go
+++ b/internal/vspd/update.go
@@ -106,7 +106,7 @@ func (v *Vspd) updateUnconfirmed(ctx context.Context, dcrdClient *rpc.DcrdRPC) {
 			continue
 		}
 
-		if tktTx.Confirmations >= requiredConfs {
+		if tktTx.Confirmations >= v.network.RequiredConfs {
 			ticket.PurchaseHeight = tktTx.BlockHeight
 			ticket.Confirmed = true
 			err = v.db.UpdateTicket(ticket)
@@ -196,7 +196,7 @@ func (v *Vspd) addToWallets(ctx context.Context, dcrdClient *rpc.DcrdRPC) {
 
 		// If fee is confirmed, update the database and add ticket to voting
 		// wallets.
-		if feeTx.Confirmations >= requiredConfs {
+		if feeTx.Confirmations >= v.network.RequiredConfs {
 			// We no longer need the hex once the tx is confirmed on-chain.
 			ticket.FeeTxHex = ""
 			ticket.FeeTxStatus = database.FeeConfirmed

--- a/internal/vspd/vspd.go
+++ b/internal/vspd/vspd.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2023 The Decred developers
+// Copyright (c) 2020-2026 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -17,10 +17,6 @@ import (
 )
 
 const (
-	// requiredConfs is the number of confirmations required to consider a
-	// ticket purchase or a fee transaction to be final.
-	requiredConfs = 6
-
 	// consistencyInterval is the time period between wallet consistency checks.
 	consistencyInterval = 30 * time.Minute
 

--- a/internal/webapi/getfeeaddress.go
+++ b/internal/webapi/getfeeaddress.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2025 The Decred developers
+// Copyright (c) 2021-2026 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -186,7 +186,7 @@ func (w *WebAPI) feeAddress(c *gin.Context) {
 	// purchase height may change due to reorgs.
 	confirmed := false
 	purchaseHeight := int64(0)
-	if rawTicket.Confirmations >= requiredConfs {
+	if rawTicket.Confirmations >= w.cfg.Network.RequiredConfs {
 		confirmed = true
 		purchaseHeight = rawTicket.BlockHeight
 	}

--- a/internal/webapi/webapi.go
+++ b/internal/webapi/webapi.go
@@ -44,9 +44,6 @@ type Config struct {
 }
 
 const (
-	// requiredConfs is the number of confirmations required to consider a
-	// ticket purchase or a fee transaction to be final.
-	requiredConfs = 6
 	// feeAddressExpiration is the length of time a fee returned by /feeaddress
 	// remains valid. After this time, a new fee must be requested.
 	feeAddressExpiration = 1 * time.Hour


### PR DESCRIPTION
On mainnet the value is 6 because a transaction with 6 confirmations can never be re-orged off of the main chain, however this value does not need to be so strict on !mainnet.