### PR TITLE
Embed web assets by default.

### DIFF
--- a/cmd/vspd/main.go
+++ b/cmd/vspd/main.go
@@ -144,6 +144,7 @@ func run() int {
 		VspClosedMsg:         cfg.VspClosedMsg,
 		AdminPass:            cfg.AdminPass,
 		Debug:                cfg.WebServerDebug,
+		EmbedWebAssets:       !cfg.DontEmbedAssets,
 		Designation:          cfg.Designation,
 		MaxVoteChangeRecords: maxVoteChangeRecords,
 		VspdVersion:          version.String(),

--- a/internal/vspd/config.go
+++ b/internal/vspd/config.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 The Decred developers
+// Copyright (c) 2021-2026 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -43,7 +43,8 @@ type Config struct {
 	WalletUsers     string        `long:"walletuser" ini-name:"walletuser" description:"Comma separated list of username for dcrwallet RPC connections."`
 	WalletPasswords string        `long:"walletpass" ini-name:"walletpass" description:"Comma separated list of password for dcrwallet RPC connections."`
 	WalletCerts     string        `long:"walletcert" ini-name:"walletcert" description:"Comma separated list of dcrwallet RPC certificate files."`
-	WebServerDebug  bool          `long:"webserverdebug" ini-name:"webserverdebug" description:"Enable web server debug mode (verbose logging to terminal and live-reloading templates)."`
+	WebServerDebug  bool          `long:"webserverdebug" ini-name:"webserverdebug" description:"Enable web server debug mode (verbose logging to terminal and live-reloading web assets)."`
+	DontEmbedAssets bool          `long:"dontembedassets" ini-name:"dontembedassets" description:"Load web assets from source dir instead of using embedded versions."`
 	SupportEmail    string        `long:"supportemail" ini-name:"supportemail" description:"Email address for users in need of support."`
 	BackupInterval  time.Duration `long:"backupinterval" ini-name:"backupinterval" description:"Time period between automatic database backups. Valid time units are {s,m,h}. Minimum 30 seconds."`
 	VspClosed       bool          `long:"vspclosed" ini-name:"vspclosed" description:"Closed prevents the VSP from accepting new tickets."`
@@ -98,19 +99,20 @@ func (cfg *Config) WalletDetails() *WalletDetails {
 }
 
 var DefaultConfig = Config{
-	Listen:         ":8800",
-	LogLevel:       "debug",
-	MaxLogSize:     int64(10),
-	LogsToKeep:     20,
-	NetworkName:    "testnet",
-	VSPFee:         3.0,
-	HomeDir:        dcrutil.AppDataDir("vspd", false),
-	DcrdHost:       "127.0.0.1",
-	WalletHosts:    "127.0.0.1",
-	WebServerDebug: false,
-	BackupInterval: time.Minute * 3,
-	VspClosed:      false,
-	Designation:    "Voting Service Provider",
+	Listen:          ":8800",
+	LogLevel:        "debug",
+	MaxLogSize:      int64(10),
+	LogsToKeep:      20,
+	NetworkName:     "testnet",
+	VSPFee:          3.0,
+	HomeDir:         dcrutil.AppDataDir("vspd", false),
+	DcrdHost:        "127.0.0.1",
+	WalletHosts:     "127.0.0.1",
+	WebServerDebug:  false,
+	DontEmbedAssets: false,
+	BackupInterval:  time.Minute * 3,
+	VspClosed:       false,
+	Designation:     "Voting Service Provider",
 }
 
 // fileExists reports whether the named file or directory exists.

--- a/internal/webapi/webapi.go
+++ b/internal/webapi/webapi.go
@@ -8,13 +8,16 @@ import (
 	"context"
 	"crypto/ed25519"
 	"crypto/sha256"
+	"embed"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"html/template"
+	"io/fs"
 	"net"
 	"net/http"
+	"os"
 	"sync"
 	"time"
 
@@ -28,6 +31,12 @@ import (
 	"github.com/gorilla/sessions"
 )
 
+//go:embed templates
+var embeddedTmplFS embed.FS
+
+//go:embed public
+var embeddedPublicFS embed.FS
+
 type Config struct {
 	Listen               string
 	VSPFee               float64
@@ -38,6 +47,7 @@ type Config struct {
 	VspClosedMsg         string
 	AdminPass            string
 	Debug                bool
+	EmbedWebAssets       bool
 	Designation          string
 	MaxVoteChangeRecords int
 	VspdVersion          string
@@ -190,6 +200,36 @@ func (w *WebAPI) Run(ctx context.Context) {
 	wg.Wait()
 }
 
+// assetFS returns filesystems from which to load public web assets and HTML
+// template files. The files are either loaded from embed or from the source dir
+// depending on config.
+func (w *WebAPI) assetFS() (http.FileSystem, http.FileSystem) {
+	useEmbedded := w.cfg.EmbedWebAssets
+
+	// Always load assets from disk when debug is enabled.
+	if w.cfg.Debug {
+		useEmbedded = false
+	}
+
+	var publicFS, tmplFS fs.FS
+	if useEmbedded {
+		tmplFS = embeddedTmplFS
+		publicFS = embeddedPublicFS
+		w.log.Debug("Using embedded web assets")
+	} else {
+		const sourceDir = "./internal/webapi"
+		tmplFS = os.DirFS(sourceDir)
+		publicFS = os.DirFS(sourceDir)
+		w.log.Debugf("Using web assets from %q", sourceDir)
+	}
+
+	// Errors can be ignored because params are hard-coded.
+	tmplFS, _ = fs.Sub(tmplFS, "templates")
+	publicFS, _ = fs.Sub(publicFS, "public")
+
+	return http.FS(publicFS), http.FS(tmplFS)
+}
+
 func (w *WebAPI) router(cookieSecret []byte, dcrd rpc.DcrdConnect, wallets rpc.WalletConnect) *gin.Engine {
 	// With release mode enabled, gin will only read template files once and cache them.
 	// With release mode disabled, templates will be reloaded on the fly.
@@ -217,7 +257,9 @@ func (w *WebAPI) router(cookieSecret []byte, dcrd rpc.DcrdConnect, wallets rpc.W
 		"pluralize":        pluralize,
 	})
 
-	router.LoadHTMLGlob("internal/webapi/templates/*.html")
+	publicFS, tmplFS := w.assetFS()
+
+	router.LoadHTMLFS(tmplFS, "*.html")
 
 	// Recovery middleware handles any go panics generated while processing web
 	// requests. Ensures a 500 response is sent to the client rather than
@@ -232,8 +274,8 @@ func (w *WebAPI) router(cookieSecret []byte, dcrd rpc.DcrdConnect, wallets rpc.W
 
 	router.Use(w.csrf())
 
-	// Serve static web resources
-	router.Static("/public", "internal/webapi/public/")
+	// Serve static web resources.
+	router.StaticFS("/public", publicFS)
 
 	// Create a cookie store for persisting admin session information.
 	cookieStore := sessions.NewCookieStore(cookieSecret)


### PR DESCRIPTION
Public web assets and HTML templates are now embedded in a compiled vspd binary and used by default, enabling the binary to be portable - it can be run from any location rather than only from the root of this repository. This is particularly useful when wishing to build the binary on one machine and run it on another.

For admins who depended on the old behaviour, e.g. those running with customized templates, loading from the source directory can be re-enabled using a new config flag `--dontembedassets`.

Assets are always loaded from the source dir when `--webserverdebug` is enabled.